### PR TITLE
move production-pipelines to always allowed

### DIFF
--- a/tokens/main.py
+++ b/tokens/main.py
@@ -9,11 +9,7 @@ import yaml
 from google.cloud import secretmanager
 
 # List of repos that are allowed for *all* datasets.
-ALWAYS_ALLOWED_REPOS = [
-    'analysis-runner',
-    'sample-metadata',
-    "production-pipelines"
-]
+ALWAYS_ALLOWED_REPOS = ['analysis-runner', 'sample-metadata', 'production-pipelines']
 
 # dataset -> list of git repos
 with open('repository-map.json', encoding='utf-8') as allowed_repo_file:

--- a/tokens/main.py
+++ b/tokens/main.py
@@ -12,6 +12,7 @@ from google.cloud import secretmanager
 ALWAYS_ALLOWED_REPOS = [
     'analysis-runner',
     'sample-metadata',
+    "production-pipelines"
 ]
 
 # dataset -> list of git repos

--- a/tokens/repository-map.json
+++ b/tokens/repository-map.json
@@ -2,21 +2,17 @@
     "acute-care": [
         "automated-interpretation-pipeline",
         "fewgenomes",
-        "gatk-sv",
-        "rare-disease"
+        "gatk-sv"
     ],
     "ag-hidden": [
-        "automated-interpretation-pipeline",
-        "rare-disease"
+        "automated-interpretation-pipeline"
     ],
     "ancestry": [
         "ancestry"
     ],
-    "bioheart": [
-    ],
+    "bioheart": [],
     "brain-malf": [
-        "automated-interpretation-pipeline",
-        "rare-disease"
+        "automated-interpretation-pipeline"
     ],
     "circa": [
         "automated-interpretation-pipeline"
@@ -25,8 +21,7 @@
         "structural-constraint"
     ],
     "epileptic-enceph": [
-        "automated-interpretation-pipeline",
-        "rare-disease"
+        "automated-interpretation-pipeline"
     ],
     "fewgenomes": [
         "automated-interpretation-pipeline",
@@ -34,13 +29,10 @@
         "images",
         "joint-calling",
         "production-pipelines",
-        "rare-disease",
         "sv-workflows"
     ],
-    "flinders-ophthal": [
-    ],
-    "gtex": [
-    ],
+    "flinders-ophthal": [],
+    "gtex": [],
     "heartkids": [
         "automated-interpretation-pipeline"
     ],
@@ -50,26 +42,20 @@
     "hgdp": [
         "hgdp"
     ],
-    "ibmdx": [
-    ],
+    "ibmdx": [],
     "kccg-genomics-med": [
         "cromwell-kccg-mutect2-chip"
     ],
     "kidgen": [
-        "automated-interpretation-pipeline",
-        "rare-disease"
+        "automated-interpretation-pipeline"
     ],
     "leukodystrophies": [
-        "automated-interpretation-pipeline",
-        "rare-disease"
+        "automated-interpretation-pipeline"
     ],
-    "mcri-lrp": [
-    ],
-    "mgrb": [
-    ],
+    "mcri-lrp": [],
+    "mgrb": [],
     "mito-disease": [
-        "automated-interpretation-pipeline",
-        "rare-disease"
+        "automated-interpretation-pipeline"
     ],
     "ohmr3-mendelian": [
         "automated-interpretation-pipeline"
@@ -96,15 +82,13 @@
         "automated-interpretation-pipeline"
     ],
     "rdp-kidney": [],
-    "reference": [
-    ],
+    "reference": [],
     "schr-neuro": [
         "automated-interpretation-pipeline"
     ],
     "seqr": [
         "hail-elasticsearch-pipelines",
-        "production-pipelines",
-        "rare-disease"
+        "production-pipelines"
     ],
     "sgs-somatic-mtn": [
         "sgs-somatic-mutation"
@@ -128,16 +112,13 @@
     "tx-adapt": [
         "tx-adapt"
     ],
-    "udn-aus": [
-    ],
-    "udn-aus-training": [
-    ],
+    "udn-aus": [],
+    "udn-aus-training": [],
     "validation": [
         "automated-interpretation-pipeline",
         "production-pipelines",
         "joint-calling",
         "gatk-sv",
-        "rare-disease",
         "large-cohort-pipeline"
     ]
 }

--- a/tokens/repository-map.json
+++ b/tokens/repository-map.json
@@ -119,6 +119,7 @@
         "production-pipelines",
         "joint-calling",
         "gatk-sv",
-        "large-cohort-pipeline"
+        "large-cohort-pipeline",
+        "rare-disease"
     ]
 }


### PR DESCRIPTION
- Move Production-pipelines to an 'always allowed' repo (linked to https://github.com/populationgenomics/production-pipelines/issues/153)
- Remove rare-disease from most repositories (The RD [data_transfer](https://github.com/populationgenomics/rare-disease/tree/main/data_transfer) scripts have already been migrated to an always-run repo [analysis-runner](https://github.com/populationgenomics/analysis-runner/tree/main/scripts), and should be removed from rare-disease)

Possible extra?
- move AIP to an always-run repo
  - currently allowed on 19/39 datasets, and likely to be applied to analysis cohorts as they are added
  - Could be useful to add to the blanket approval list and save a few PRs later