### PR TITLE
Add sv-workflows repo to hereditary-neuro project

### DIFF
--- a/tokens/repository-map.json
+++ b/tokens/repository-map.json
@@ -37,7 +37,8 @@
         "automated-interpretation-pipeline"
     ],
     "hereditary-neuro": [
-        "automated-interpretation-pipeline"
+        "automated-interpretation-pipeline",
+        "sv-workflows"
     ],
     "hgdp": [
         "hgdp"


### PR DESCRIPTION
Allow Hope's STR calling scripts to run on the hereditary-neuro cohort.