### PR TITLE
Add lifecycle rule to GCP buckets to delete incomplete multipart uploads

### DIFF
--- a/cpg_infra/abstraction/base.py
+++ b/cpg_infra/abstraction/base.py
@@ -29,7 +29,7 @@ from cpg_infra.config import (
 UNDELETE_PERIOD_IN_DAYS = 30
 TMP_BUCKET_PERIOD_IN_DAYS = 8  # tmp content gets deleted afterwards.
 ARCHIVE_PERIOD_IN_DAYS = 30
-
+BUCKET_DELETE_INCOMPLETE_UPLOAD_PERIOD_IN_DAYS = 7
 
 class SecretMembership(Enum):
     """Secret membership pattern"""

--- a/cpg_infra/abstraction/base.py
+++ b/cpg_infra/abstraction/base.py
@@ -31,6 +31,7 @@ TMP_BUCKET_PERIOD_IN_DAYS = 8  # tmp content gets deleted afterwards.
 ARCHIVE_PERIOD_IN_DAYS = 30
 BUCKET_DELETE_INCOMPLETE_UPLOAD_PERIOD_IN_DAYS = 7
 
+
 class SecretMembership(Enum):
     """Secret membership pattern"""
 

--- a/cpg_infra/abstraction/gcp.py
+++ b/cpg_infra/abstraction/gcp.py
@@ -252,9 +252,11 @@ class GcpInfrastructure(CloudInfraBase):
             unique_bucket_name = (
                 f'{self.config.dataset_storage_prefix}{self.dataset}-{name}'
             )
-
-        _lifecycle_rules = list(lifecycle_rules or [])
-        _lifecycle_rules.append(self.bucket_rule_abort_incomplete_multipart_upload())
+        # duplicate the array to avoid adding the lifecycle rule to an existing list
+        _lifecycle_rules = [
+            *lifecycle_rules,
+            self.bucket_rule_abort_incomplete_multipart_upload(),
+        ]
 
         return gcp.storage.Bucket(
             unique_bucket_name,

--- a/cpg_infra/abstraction/gcp.py
+++ b/cpg_infra/abstraction/gcp.py
@@ -252,11 +252,6 @@ class GcpInfrastructure(CloudInfraBase):
             unique_bucket_name = (
                 f'{self.config.dataset_storage_prefix}{self.dataset}-{name}'
             )
-        # duplicate the array to avoid adding the lifecycle rule to an existing list
-        _lifecycle_rules = [
-            *lifecycle_rules,
-            self.bucket_rule_abort_incomplete_multipart_upload(),
-        ]
 
         return gcp.storage.Bucket(
             unique_bucket_name,
@@ -265,7 +260,11 @@ class GcpInfrastructure(CloudInfraBase):
             uniform_bucket_level_access=True,
             versioning=gcp.storage.BucketVersioningArgs(enabled=versioning),
             labels={'bucket': unique_bucket_name},
-            lifecycle_rules=_lifecycle_rules,
+            # duplicate the array to avoid adding the lifecycle rule to an existing list
+            lifecycle_rules=[
+                *lifecycle_rules,
+                self.bucket_rule_abort_incomplete_multipart_upload(),
+            ],
             requester_pays=requester_pays,
             project=project or self.project_id,
         )

--- a/cpg_infra/abstraction/gcp.py
+++ b/cpg_infra/abstraction/gcp.py
@@ -229,7 +229,7 @@ class GcpInfrastructure(CloudInfraBase):
         self, days=BUCKET_DELETE_INCOMPLETE_UPLOAD_PERIOD_IN_DAYS
     ):
         """
-        Life cycle rule that deletes incomplete multipart uploads after n days
+        Lifecycle rule that deletes incomplete multipart uploads after n days
         """
         return gcp.storage.BucketLifecycleRuleArgs(
             action=gcp.storage.BucketLifecycleRuleActionArgs(


### PR DESCRIPTION
Context: https://centrepopgen.slack.com/archives/C03FZL2EF24/p1666607536387039