### PR TITLE
Implement container registry for a dataset

### DIFF
--- a/cpg_infra/abstraction/base.py
+++ b/cpg_infra/abstraction/base.py
@@ -1,4 +1,4 @@
-# pylint: disable=missing-function-docstring,unnecessary-pass
+# pylint: disable=missing-function-docstring,unnecessary-pass,too-many-public-methods
 """
 Generic Infrastructure abstraction that relies on each to be subclassed
 by an equivalent GCP / Azure implementation.

--- a/cpg_infra/abstraction/base.py
+++ b/cpg_infra/abstraction/base.py
@@ -229,6 +229,10 @@ class CloudInfraBase(ABC):
         # TODO: this might need more thought
         pass
 
+    @abstractmethod
+    def create_container_registry(self, name: str):
+        pass
+
 
 # DEV OVERRIDE
 

--- a/cpg_infra/abstraction/base.py
+++ b/cpg_infra/abstraction/base.py
@@ -52,7 +52,7 @@ class ContainerRegistryMembership(Enum):
     """Container registry membership type"""
 
     READER = 'reader'
-    APPEND = 'append'
+    WRITER = 'writer'
 
 
 class CloudInfraBase(ABC):

--- a/cpg_infra/abstraction/gcp.py
+++ b/cpg_infra/abstraction/gcp.py
@@ -480,6 +480,17 @@ class GcpInfrastructure(CloudInfraBase):
             resource_key, secret=secret.id, secret_data=contents
         )
 
+    # region CONTAINER REGISTRY
+
+    def create_container_registry(self, name: str):
+        return gcp.artifactregistry.Repository(
+            'artifact-registry-' + name,
+            repository_id=name,
+            project=self.project_id,
+            format='DOCKER',
+            location=self.region,
+        )
+
     def add_member_to_container_registry(
         self, resource_key: str, registry, member, membership, project=None
     ) -> Any:
@@ -499,6 +510,8 @@ class GcpInfrastructure(CloudInfraBase):
             role=role,
             member=self.get_member_key(member),
         )
+
+    # endregion CONTAINER REGISTRY
 
     # region GCP SPECIFIC
 

--- a/cpg_infra/abstraction/gcp.py
+++ b/cpg_infra/abstraction/gcp.py
@@ -497,7 +497,7 @@ class GcpInfrastructure(CloudInfraBase):
 
         if membership == ContainerRegistryMembership.READER:
             role = 'roles/artifactregistry.reader'
-        elif membership == ContainerRegistryMembership.APPEND:
+        elif membership == ContainerRegistryMembership.WRITER:
             role = 'roles/artifactregistry.writer'
         else:
             raise ValueError(f'Unrecognised group membership type: {membership}')

--- a/cpg_infra/config.py
+++ b/cpg_infra/config.py
@@ -226,6 +226,8 @@ class CPGDatasetConfig(DeserializableDataclass):
     deployment_service_account_standard: str | None = None
     deployment_service_account_full: str | None = None
 
+    create_container_registry: bool = False
+
     deploy_locations: list[str] = dataclasses.field(default_factory=lambda: ['gcp'])
 
     # creates a release requester-pays bucket

--- a/cpg_infra/driver.py
+++ b/cpg_infra/driver.py
@@ -988,7 +988,6 @@ class CpgDatasetInfrastructure:
                     membership=ContainerRegistryMembership.APPEND,
                 )
 
-
     def setup_inherited_container_registries(self):
         """
         Setup permissions for cpg-common + analysis-runner artifact registries

--- a/cpg_infra/driver.py
+++ b/cpg_infra/driver.py
@@ -961,7 +961,7 @@ class CpgDatasetInfrastructure:
         :return:
         """
         self.setup_dataset_container_registry()
-        self.setup_inherited_container_registries()
+        self.setup_legacy_container_registries()
 
     def setup_dataset_container_registry(self):
         """
@@ -985,10 +985,10 @@ class CpgDatasetInfrastructure:
                     f'{kind}-images-writer-in-container-registry',
                     registry=custom_container_registry,
                     member=account,
-                    membership=ContainerRegistryMembership.APPEND,
+                    membership=ContainerRegistryMembership.WRITER,
                 )
 
-    def setup_inherited_container_registries(self):
+    def setup_legacy_container_registries(self):
         """
         Setup permissions for cpg-common + analysis-runner artifact registries
         """
@@ -1030,7 +1030,7 @@ class CpgDatasetInfrastructure:
                 registry=self.config.gcp.common_artifact_registry_name,
                 project=self.config.gcp.common_artifact_registry_project,
                 member=self.access_level_groups[kind],
-                membership=ContainerRegistryMembership.APPEND,
+                membership=ContainerRegistryMembership.WRITER,
             )
 
     # endregion CONTAINER REGISTRY

--- a/stack/Pulumi.fewgenomes.yaml
+++ b/stack/Pulumi.fewgenomes.yaml
@@ -5,6 +5,7 @@ config:
   datasets:gcp_hail_service_account_full: fewgenomes-full-915@hail-295901.iam.gserviceaccount.com
   datasets:gcp_hail_service_account_standard: fewgenomes-standard-737@hail-295901.iam.gserviceaccount.com
   datasets:gcp_hail_service_account_test: fewgenomes-test-126@hail-295901.iam.gserviceaccount.com
+  datasets:create_container_registry: "true"
   gcp:billing_project: fewgenomes
   gcp:project: fewgenomes
   gcp:user_project_override: "true"

--- a/stack/Pulumi.fewgenomes.yaml
+++ b/stack/Pulumi.fewgenomes.yaml
@@ -5,7 +5,6 @@ config:
   datasets:gcp_hail_service_account_full: fewgenomes-full-915@hail-295901.iam.gserviceaccount.com
   datasets:gcp_hail_service_account_standard: fewgenomes-standard-737@hail-295901.iam.gserviceaccount.com
   datasets:gcp_hail_service_account_test: fewgenomes-test-126@hail-295901.iam.gserviceaccount.com
-  datasets:create_container_registry: "true"
   gcp:billing_project: fewgenomes
   gcp:project: fewgenomes
   gcp:user_project_override: "true"


### PR DESCRIPTION
Will be useful for a universially dependent `cpg-common` dataset with an artifact registry, eventually removing the support for specifying cpg-common manually.

\+ Import the pre-existing fewgenomes repository.