### PR TITLE
Gracefully handle groups without members for cache blobs

### DIFF
--- a/cpg_infra/driver.py
+++ b/cpg_infra/driver.py
@@ -281,7 +281,7 @@ class CPGInfrastructure:
                     infra.add_blob_to_bucket(
                         f'{group.name}-group-cache-members',
                         bucket=self.gcp_members_cache_bucket,
-                        contents=members_contents,
+                        contents=members_contents + '\n',
                         output_name=f'{group.name}-members.txt',
                     )
 


### PR DESCRIPTION
Context: https://centrepopgen.slack.com/archives/C03FZL2EF24/p1675647031435499?thread_ts=1675646555.315329&cid=C03FZL2EF24

Looks like Pulumi doesn't like to create empty blobs for empty groups, so we add a newline in the end.

This is handled fine when reading: https://cs.github.com/populationgenomics/cpg-utils/blob/f9f63b64fc0b79ffb62291ff478f5b5b2933ddfa/cpg_utils/cloud.py?q=is_member_in_cached_group#L307