### PR TITLE
Revert "Gracefully handle groups without members for cache blobs (#46)"

### DIFF
--- a/cpg_infra/driver.py
+++ b/cpg_infra/driver.py
@@ -281,7 +281,7 @@ class CPGInfrastructure:
                     infra.add_blob_to_bucket(
                         f'{group.name}-group-cache-members',
                         bucket=self.gcp_members_cache_bucket,
-                        contents=members_contents + '\n',
+                        contents=members_contents,
                         output_name=f'{group.name}-members.txt',
                     )
 


### PR DESCRIPTION
This reverts commit 19716733a0b67f9b3f28faa12028f47dcbf43dec.

Context: https://centrepopgen.slack.com/archives/C03FZL2EF24/p1675662078878649?thread_ts=1675659698.052339&cid=C03FZL2EF24