### PR TITLE
Update pulumi-gcp to get BucketAutoclassArgs support

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 pulumi==3.37.2
-pulumi-gcp==6.32.0
+pulumi-gcp==6.49.0
 pulumi-azure-native==1.80.0
 pulumi-azuread==5.28.0
 toml==0.10.2

--- a/stack/requirements.txt
+++ b/stack/requirements.txt
@@ -1,5 +1,5 @@
 pulumi==3.37.2
-pulumi-gcp==6.32.0
+pulumi-gcp==6.49.0
 google-cloud-billing-budgets==1.5.1
 requests==2.27.1
 PyYAML==5.4.1


### PR DESCRIPTION
This will be useful to clean up the state after migrating to Autoclass buckets, but I'd like to apply any unrelated changes independently, to avoid confusion.