### PR TITLE
Move default to UTC time

### DIFF
--- a/cpg_infra/billing_aggregator/aggregate/utils.py
+++ b/cpg_infra/billing_aggregator/aggregate/utils.py
@@ -883,7 +883,7 @@ def process_default_start_and_end(
     """
     if not end:
         # start right now
-        end = datetime.now()
+        end = datetime.utcnow()
     if not start:
         start = end - interval
 


### PR DESCRIPTION
With interval less than the AEDT offset, this is missing all GCP billing data.