### PR TITLE
Increase CPU to redeploy billing_aggregator

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -30,6 +30,6 @@ max-line-length=88
 # Maximum number of locals for function / method body
 max-locals=40
 # Maximum number of arguments for function / method
-max-args=10
+max-args=15
 # Maximum number of branches per function
 max-branches=30

--- a/cpg_infra/billing_aggregator/driver.py
+++ b/cpg_infra/billing_aggregator/driver.py
@@ -284,7 +284,7 @@ class BillingAggregator:
         env: dict,
         source_file: str | None = None,
         memory: str = '512M',
-        cpu: int | None = None
+        cpu: int | None = None,
     ):
         """
         Create a single Cloud Function. Include the pubsub trigger and event alerts


### PR DESCRIPTION
Initial deploy failed as the increase of memory needs to align with an increase in CPU by this table: https://cloud.google.com/functions/docs/configuring/memory