### PR TITLE
Add hail accounts secret_accessor to hail-git-token

### DIFF
--- a/cpg_infra/config.py
+++ b/cpg_infra/config.py
@@ -98,6 +98,8 @@ class CPGInfrastructureConfig(DeserializableDataclass):
         class GCP(DeserializableDataclass):
             wheel_bucket_name: str
             hail_batch_url: str
+            git_credentials_secret_name: str
+            git_credentials_secret_project: str
 
         @dataclasses.dataclass(frozen=True)
         class Azure(DeserializableDataclass):


### PR DESCRIPTION
- Support checking our private repositories from hail
- Add token in infrastructure config for use by analysis-runner