### PR TITLE
Fix non-callable resp.text call for hailbatch

### DIFF
--- a/cpg_infra/abstraction/hailbatch.py
+++ b/cpg_infra/abstraction/hailbatch.py
@@ -61,7 +61,7 @@ def get_hail_batch_billing_project(name: str, token_category: str, batch_uri: st
     )
     if resp.status_code == 404:
         return None
-    if resp.status_code == 403 and 'Unknown Hail Batch' in resp.text():
+    if resp.status_code == 403 and 'Unknown Hail Batch' in resp.text:
         # Ignore 403: Unknown Hail Batch billing project <project>
         return None
 


### PR DESCRIPTION
I think mypy would've caught this, so I'll look at adding it into this repo