### PR TITLE
Split dataset storage prefix by cloud

### DIFF
--- a/cpg_infra/abstraction/azure.py
+++ b/cpg_infra/abstraction/azure.py
@@ -40,10 +40,11 @@ class AzureInfra(CloudInfraBase):
 
         assert config.azure, 'config.azure is required to deploy to Azure'
 
+        self.dataset_storage_prefix = config.azure.dataset_storage_prefix
         self.region = config.azure.region
-        self._resource_group_name = f'{config.dataset_storage_prefix}{self.dataset}'
+        self._resource_group_name = f'{self.dataset_storage_prefix}{self.dataset}'
         self._storage_account_name = self.fix_azure_alphanum_names(
-            f'{config.dataset_storage_prefix}{self.dataset}'
+            f'{self.dataset_storage_prefix}{self.dataset}'
         )
         self.storage_account_lifecycle_rules: list[Any] = []
         self.storage_account_undelete_rule = None

--- a/cpg_infra/abstraction/azure.py
+++ b/cpg_infra/abstraction/azure.py
@@ -549,7 +549,7 @@ class AzureInfra(CloudInfraBase):
             admin_user_enabled=True,
             location=self.region,
             registry_name=self.fix_azure_alphanum_names(
-                self.config.dataset_storage_prefix + self.dataset + name
+                self.config.azure.dataset_storage_prefix + self.dataset + name
             ),
             resource_group_name=self.resource_group.name,
             sku=az.containerregistry.SkuArgs(

--- a/cpg_infra/abstraction/gcp.py
+++ b/cpg_infra/abstraction/gcp.py
@@ -309,7 +309,7 @@ class GcpInfrastructure(CloudInfraBase):
         unique_bucket_name = name
         if not unique:
             unique_bucket_name = (
-                f'{self.config.dataset_storage_prefix}{self.dataset}-{name}'
+                f'{self.config.gcp.dataset_storage_prefix}{self.dataset}-{name}'
             )
 
         def autoclass_args():

--- a/cpg_infra/billing_aggregator/driver.py
+++ b/cpg_infra/billing_aggregator/driver.py
@@ -100,7 +100,7 @@ class BillingAggregator:
         """
         return gcp.storage.Bucket(
             f'billing-aggregator-source-bucket',
-            name=f'{self.config.dataset_storage_prefix}aggregator-source-bucket',
+            name=f'{self.config.gcp.dataset_storage_prefix}aggregator-source-bucket',
             location=self.config.gcp.region,
             project=self.config.billing.gcp.project_id,
             uniform_bucket_level_access=True,

--- a/cpg_infra/config.py
+++ b/cpg_infra/config.py
@@ -89,12 +89,14 @@ class CPGInfrastructureConfig(DeserializableDataclass):
         groups_domain: str
         budget_notification_pubsub: str | None
         config_bucket_name: str
+        dataset_storage_prefix: str
 
     @dataclasses.dataclass(frozen=True)
     class Azure(DeserializableDataclass):
         region: str
         subscription: str
         tenant: str
+        dataset_storage_prefix: str
         config_bucket_name: str
 
     @dataclasses.dataclass(frozen=True)
@@ -184,7 +186,6 @@ class CPGInfrastructureConfig(DeserializableDataclass):
         hail_aggregator_username: str | None = None
 
     domain: str
-    dataset_storage_prefix: str
     budget_currency: str
     common_dataset: str
     web_url_template: str

--- a/cpg_infra/driver.py
+++ b/cpg_infra/driver.py
@@ -449,7 +449,7 @@ class CPGInfrastructure:
     def gcp_members_cache_bucket(self):
         reference_infra = self.dataset_infrastructure['gcp'][self.config.common_dataset]
         return reference_infra.infra.create_bucket(
-            f'{self.config.dataset_storage_prefix}members-group-cache',
+            f'{self.config.gcp.dataset_storage_prefix}members-group-cache',
             unique=True,
             versioning=True,
             autoclass=False,  # Always accessed frequently.


### PR DESCRIPTION
When I tore down our infrastructure, it didn't delete the accounts properly, so now `cpgcommon` is permanently unavailable, and only allowed `[a-z][a-z0-9]{3,24}` so we're quite stuck except to append number or pick a new prefix