### PR TITLE
Metamist project creation + small dataset manager refactor

### DIFF
--- a/cpg_infra/abstraction/metamist.py
+++ b/cpg_infra/abstraction/metamist.py
@@ -32,26 +32,21 @@ class MetamistProjectProvider(pulumi.dynamic.ResourceProvider):
         name = props['project_name']
         create_test_project = props['create_test_project']
 
-        existing_project = get_project_by_name(name)
-        if existing_project:
-            return pulumi.dynamic.CreateResult(
-                id_=f'metamist-project::{name}::{existing_project["id"]}',
-                outs={
-                    'id': existing_project['id'],
-                    'name': name,
-                },
+        project = get_project_by_name(name)
+        if not project:
+            project = ProjectApi().create_project(
+                name=name,
+                dataset=name,
+                create_test_project=create_test_project,
             )
+        if not project:
+            raise Exception(f'Failed to create project {name}')
 
-        project = ProjectApi().create_project(
-            name=name,
-            dataset=name,
-            create_test_project=create_test_project,
-        )
-
+        project_id = project['id']
         return pulumi.dynamic.CreateResult(
-            id_=f'metamist-project::{name}::{project["id"]}',
+            id_=f'metamist-project::{name}::{project_id}',
             outs={
-                'id': project['id'],
+                'id': project_id,
                 'name': name,
             },
         )

--- a/cpg_infra/abstraction/metamist.py
+++ b/cpg_infra/abstraction/metamist.py
@@ -1,0 +1,99 @@
+"""
+Pulumi provider for interacting with metamist
+"""
+import functools
+import pulumi
+from metamist.apis import ProjectApi
+
+
+@functools.lru_cache()
+def get_projects() -> dict[str, dict]:
+    """
+    Get all projects from metamist, useful to avoid repeated calls to the API
+    :return:
+    """
+    api = ProjectApi()
+    all_projects = api.get_all_projects()
+    return {p['name']: p for p in all_projects}
+
+
+def get_project_by_name(name: str) -> dict | None:
+    """
+    Get a project by name from metamist, uses the cached get_projects() function
+    """
+    projects = get_projects()
+    return projects.get(name)
+
+
+class MetamistProjectProvider(pulumi.dynamic.ResourceProvider):
+    """Pulumi provider for creating a metamist project"""
+
+    def create(self, props) -> pulumi.dynamic.CreateResult:
+        name = props['project_name']
+        create_test_project = props['create_test_project']
+
+        existing_project = get_project_by_name(name)
+        if existing_project:
+            return pulumi.dynamic.CreateResult(
+                id_=f'metamist-project::{name}::{existing_project["id"]}',
+                outs={
+                    'id': existing_project['id'],
+                    'name': name,
+                },
+            )
+
+        project = ProjectApi().create_project(
+            name=name,
+            dataset=name,
+            create_test_project=create_test_project,
+        )
+
+        return pulumi.dynamic.CreateResult(
+            id_=f'metamist-project::{name}::{project["id"]}',
+            outs={
+                'id': project['id'],
+                'name': name,
+            },
+        )
+
+    def diff(self, _id: str, _olds, _news) -> pulumi.dynamic.DiffResult:
+        replaces = []
+
+        if _olds['project_name'] != _news['project_name']:
+            replaces.append('name')
+
+        return pulumi.dynamic.DiffResult(
+            changes=len(replaces) > 0,
+            replaces=replaces,
+            delete_before_replace=len(replaces) > 0,
+        )
+
+    def delete(self, _id: str, _props) -> None:
+        # don't delete projects
+        pass
+
+    def read(self, id_: str, props) -> pulumi.dynamic.ReadResult:
+        project = get_project_by_name(props['project_name'])
+        if not project:
+            return pulumi.dynamic.ReadResult(None, {})
+
+        return pulumi.dynamic.ReadResult(id_=id_, outs=props)
+
+
+class MetamistProject(pulumi.dynamic.Resource):
+    """Create a membership to a Hail Batch Billing Project"""
+
+    project_id: pulumi.Output[int]
+
+    def __init__(
+        self,
+        name: str,
+        project_name: str,
+        create_test_project: bool = True,
+        opts: pulumi.ResourceOptions | None = None,
+    ):
+        args = {
+            'project_name': project_name,
+            'create_test_project': create_test_project,
+        }
+        super().__init__(MetamistProjectProvider(), name, args, opts)

--- a/cpg_infra/abstraction/metamist.py
+++ b/cpg_infra/abstraction/metamist.py
@@ -6,7 +6,7 @@ import pulumi
 from metamist.apis import ProjectApi
 
 
-@functools.lru_cache()
+@functools.cache
 def get_projects() -> dict[str, dict]:
     """
     Get all projects from metamist, useful to avoid repeated calls to the API

--- a/cpg_infra/abstraction/metamist.py
+++ b/cpg_infra/abstraction/metamist.py
@@ -40,14 +40,14 @@ class MetamistProjectProvider(pulumi.dynamic.ResourceProvider):
                 create_test_project=create_test_project,
             )
         if not project:
-            raise Exception(f'Failed to create project {name}')
+            raise RuntimeError(f'Failed to create project {name}')
 
         project_id = project['id']
         return pulumi.dynamic.CreateResult(
             id_=f'metamist-project::{name}::{project_id}',
             outs={
                 'id': project_id,
-                'name': name,
+                'project_name': name,
             },
         )
 
@@ -55,7 +55,7 @@ class MetamistProjectProvider(pulumi.dynamic.ResourceProvider):
         replaces = []
 
         if _olds['project_name'] != _news['project_name']:
-            replaces.append('name')
+            replaces.append('project_name')
 
         return pulumi.dynamic.DiffResult(
             changes=len(replaces) > 0,

--- a/cpg_infra/config/config.py
+++ b/cpg_infra/config/config.py
@@ -288,6 +288,7 @@ class CPGDatasetConfig(DeserializableDataclass):
     # creates a release requester-pays bucket
     enable_release: bool = False
     enable_shared_project: bool = False
+    setup_metamist_project: bool = True
     # give access for this dataset to access any other it depends on
     depends_on: list[str] = dataclasses.field(default_factory=list)
     depends_on_readonly: list[str] = dataclasses.field(default_factory=list)

--- a/cpg_infra/config/config.py
+++ b/cpg_infra/config/config.py
@@ -288,7 +288,7 @@ class CPGDatasetConfig(DeserializableDataclass):
     # creates a release requester-pays bucket
     enable_release: bool = False
     enable_shared_project: bool = False
-    setup_metamist_project: bool = True
+    enable_metamist_project: bool = True
     # give access for this dataset to access any other it depends on
     depends_on: list[str] = dataclasses.field(default_factory=list)
     depends_on_readonly: list[str] = dataclasses.field(default_factory=list)

--- a/cpg_infra/driver.py
+++ b/cpg_infra/driver.py
@@ -145,7 +145,6 @@ class CPGInfrastructure:
                         )
                     self.members[resource_key] = self.GroupMember(member, None)
 
-
             def __repr__(self):
                 return f'Group({self.name!r})'
 
@@ -231,7 +230,9 @@ class CPGInfrastructure:
             group_prefix=self.config.group_prefix
         )
 
-        self.dataset_infrastructures: dict[str, CPGDatasetInfrastructure] = defaultdict()
+        self.dataset_infrastructures: dict[
+            str, CPGDatasetInfrastructure
+        ] = defaultdict()
 
     @cached_property
     def common_dataset(self) -> 'CPGDatasetInfrastructure':
@@ -333,7 +334,10 @@ class CPGInfrastructure:
                     if m.user and m.user.hail_batch_username
                 ]
 
-                def _make_add_member_function(_data_provider: CPGDatasetCloudInfrastructure, _infra: CloudInfraBase):
+                def _make_add_member_function(
+                    _data_provider: 'CPGDatasetCloudInfrastructure',
+                    _infra: CloudInfraBase,
+                ):
                     # bind loop variables so they're available in
                     # the functional context below
 
@@ -1050,7 +1054,9 @@ class CPGDatasetCloudInfrastructure:
         for namespace, al_buckets in buckets.items():
             configs_to_merge = []
             for dependent_dataset in sorted(dependent_datasets):
-                if cloud_infra := stacks_to_reference[dependent_dataset].clouds.get(self.infra.name()):
+                if cloud_infra := stacks_to_reference[dependent_dataset].clouds.get(
+                    self.infra.name()
+                ):
                     if config := cloud_infra.storage_tomls.get(namespace):
                         configs_to_merge.append(config)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,7 @@ pulumi==3.69.0
 toml-sort
 toml==0.10.2
 xxhash==3.2.0
+metamist
 # https://tenor.com/en-GB/view/magic-gif-26166638
 # TODO: remove the @add-infrastructure just before merging
 metamist-infrastructure @ git+https://github.com/populationgenomics/sample-metadata.git@b5f53778de372af47c36120cd1e3662f17db8fa3#subdirectory=metamist_infrastructure


### PR DESCRIPTION
Create the metamist project through Pulumi through another dynamic resource provider.
We only want to create _one_ per dataset, so now is a natural point to make the model support this.

Now, insert a new CPGDatasetInfrastructure in between CPGInfrastructure and CPGDatasetCloudInfrastructure. And make the generic Dataset one do the instantiation of the clouds. Simplified some logic at the top level, allows for single dataset infrastructure in one of the specific cloud providers (or cloud agnostic).

Introduces some simplifications, like accessing the "common" dataset to create infrastructure in, at the top level.

Adds `metamist` as a dependency (the new pypi version, even though it's not technically current, the method names for project won't change).