### PR TITLE
Fix bucket_rule_temporary() docstring

### DIFF
--- a/cpg_infra/abstraction/base.py
+++ b/cpg_infra/abstraction/base.py
@@ -161,7 +161,7 @@ class CloudInfraBase(ABC):
     @abstractmethod
     def bucket_rule_temporary(self, days=TMP_BUCKET_PERIOD_IN_DAYS) -> Any:
         """
-        Return a lifecycle_rule that stores data for n days after delete"""
+        Return a lifecycle_rule that deletes data n days after its creation"""
         pass
 
     @abstractmethod


### PR DESCRIPTION
This had been left as copy/pasted from the adjacent function definition.

This is indeed _n_ days after creation (one might guess it could instead be _n_ days after the last access):

* The _azure.py_ implementation uses `days_after_modification_greater_than`, which is unambiguous;
* The _gcp.py_ implementation sets `gcp.storage.BucketLifecycleRuleConditionArgs(age=days)`, and `age` is described as being “[measured from the resource's creation time](https://cloud.google.com/storage/docs/lifecycle#age)”.