### PR TITLE
Authenticate GitHub access in actions workflows

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -9,9 +9,9 @@ jobs:
         shell: bash -l {0}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         with:
           python-version: "3.11"
           cache: "pip"
@@ -36,7 +36,7 @@ jobs:
           rc=$?
           coverage xml
 
-          echo "::set-output name=rc::$rc"
+          echo "rc=$rc" >> $GITHUB_OUTPUT
 
 # configure this later
 #      - name: "Upload coverage report"

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -16,6 +16,13 @@ jobs:
           python-version: "3.11"
           cache: "pip"
 
+      - name: Authenticate to GitHub
+        env:
+          TOKEN: ${{ secrets.SAMPLE_METADATA_REPO_TOKEN }}
+        run: |
+          git config --global credential.helper store
+          echo "$TOKEN" | git credential approve
+
       - name: Install packages
         run: |
           pip install \

--- a/.github/workflows/preview.yaml
+++ b/.github/workflows/preview.yaml
@@ -31,6 +31,13 @@ jobs:
           python-version: "3.11"
           cache: "pip" # caching pip dependencies
 
+      - name: "Authenticate to GitHub"
+        env:
+          TOKEN: ${{ secrets.SAMPLE_METADATA_REPO_TOKEN }}
+        run: |
+          git config --global credential.helper store
+          echo "$TOKEN" | git credential approve
+
       - id: "auth-azure"
         name: "Authenticate to Azure Cloud"
         uses: azure/login@v1


### PR DESCRIPTION
Akin to populationgenomics/cpg-infrastructure-private#182, this sets up `git+https://` authentication credentials via a credential helper in each of the workflows that needs to pip install metamist-infrastructure, which is done by checking out the relevant code from the sample-metadata repository — which is currently private so accessing it requires credentials.

See the cpg-infrastructure-private PR for further details of the technique used.