### PR TITLE
Changes to SampleMetadata config class.

### DIFF
--- a/cpg_infra/config/config.py
+++ b/cpg_infra/config/config.py
@@ -124,7 +124,7 @@ class CPGInfrastructureConfig(DeserializableDataclass):
         slack_channel: str | None = None
         etl_accessors: list[str] = dataclasses.field(default_factory=list)
         # Metamist environment (DEVELOPMENT / PRODUCTION) for ETL cloud functions
-        etl_environment: str | None = None
+        etl_environment: str | None = 'PRODUCTION'
         # Default ETL parser configuration, if not specified in ETL payload
         # e.g.: {'project': 'greek-myth', 'default_sequencing_type': 'genome'}
         etl_parser_default_config: dict[str, str] | None = None

--- a/cpg_infra/config/config.py
+++ b/cpg_infra/config/config.py
@@ -126,6 +126,7 @@ class CPGInfrastructureConfig(DeserializableDataclass):
         # Metamist environment (DEVELOPMENT / PRODUCTION) for ETL cloud functions
         etl_environment: str | None = None
         # Default ETL parser configuration, if not specified in ETL payload
+        # e.g.: {'project': 'greek-myth', 'default_sequencing_type': 'genome'}
         etl_parser_default_config: dict[str, str] | None = None
         # Collection of private packages for ETL functions appended to requirements.txt
         etl_private_repo_packages: list[str] | None = None

--- a/cpg_infra/config/config.py
+++ b/cpg_infra/config/config.py
@@ -123,6 +123,10 @@ class CPGInfrastructureConfig(DeserializableDataclass):
         gcp: GCP
         slack_channel: str | None = None
         etl_accessors: list[str] = dataclasses.field(default_factory=list)
+        etl_environment: str | None = None
+        etl_default_config: dict[str, str] | None = None
+        etl_private_repo_url: str | None = None
+        etl_private_repo_packages: str | None = None
 
     @dataclasses.dataclass(frozen=True)
     class Billing(DeserializableDataclass):

--- a/cpg_infra/config/config.py
+++ b/cpg_infra/config/config.py
@@ -123,10 +123,12 @@ class CPGInfrastructureConfig(DeserializableDataclass):
         gcp: GCP
         slack_channel: str | None = None
         etl_accessors: list[str] = dataclasses.field(default_factory=list)
+        # Metamist environment (DEVELOPMENT / PRODUCTION) for ETL cloud functions
         etl_environment: str | None = None
-        etl_default_config: dict[str, str] | None = None
-        etl_private_repo_url: str | None = None
-        etl_private_repo_packages: str | None = None
+        # Default ETL parser configuration, if not specified in ETL payload
+        etl_parser_default_config: dict[str, str] | None = None
+        # Collection of private packages for ETL functions appended to requirements.txt
+        etl_private_repo_packages: list[str] | None = None
 
     @dataclasses.dataclass(frozen=True)
     class Billing(DeserializableDataclass):


### PR DESCRIPTION
Before we can deploy the latest Metamist ETL, we would need to add extra config to SampleMetadata class, here are my suggestions.
All are prefixed as ETL_
