### PR TITLE
Artifact registry v2 (+ req bump)

### DIFF
--- a/cpg_infra/driver.py
+++ b/cpg_infra/driver.py
@@ -17,17 +17,27 @@ import xxhash
 from toml_sort import TomlSort
 
 from cpg_infra.abstraction.azure import AzureInfra
-from cpg_infra.abstraction.base import (BucketMembership, CloudInfraBase,
-                                        ContainerRegistryMembership,
-                                        DryRunInfra, MachineAccountRole,
-                                        SecretMembership)
+from cpg_infra.abstraction.base import (
+    BucketMembership,
+    CloudInfraBase,
+    ContainerRegistryMembership,
+    DryRunInfra,
+    MachineAccountRole,
+    SecretMembership,
+)
 from cpg_infra.abstraction.gcp import GcpInfrastructure
-from cpg_infra.abstraction.hailbatch import (HailBatchBillingProject,
-                                             HailBatchBillingProjectMembership)
+from cpg_infra.abstraction.hailbatch import (
+    HailBatchBillingProject,
+    HailBatchBillingProjectMembership,
+)
 from cpg_infra.abstraction.metamist import MetamistProject
-from cpg_infra.config import (CPGDatasetComponents, CPGDatasetConfig,
-                              CPGInfrastructureConfig, CPGInfrastructureUser,
-                              HailAccount)
+from cpg_infra.config import (
+    CPGDatasetComponents,
+    CPGDatasetConfig,
+    CPGInfrastructureConfig,
+    CPGInfrastructureUser,
+    HailAccount,
+)
 from cpg_infra.plugin import get_plugins
 
 SampleMetadataAccessorMembership = namedtuple(

--- a/cpg_infra/driver.py
+++ b/cpg_infra/driver.py
@@ -2,41 +2,32 @@
 """
 CPG Dataset infrastructure
 """
-import re
-import os.path
 import graphlib
-from typing import Type, Any, Iterator, Iterable
+import os.path
+import re
 from collections import defaultdict, namedtuple
 from functools import cached_property
-from toml_sort import TomlSort
+from typing import Any, Iterable, Iterator, Type
 
+import cpg_utils.config
+import pulumi
+import pulumi_gcp as gcp
 import toml
 import xxhash
-import pulumi
-import cpg_utils.config
+from toml_sort import TomlSort
 
 from cpg_infra.abstraction.azure import AzureInfra
+from cpg_infra.abstraction.base import (BucketMembership, CloudInfraBase,
+                                        ContainerRegistryMembership,
+                                        DryRunInfra, MachineAccountRole,
+                                        SecretMembership)
 from cpg_infra.abstraction.gcp import GcpInfrastructure
-from cpg_infra.abstraction.base import (
-    CloudInfraBase,
-    DryRunInfra,
-    SecretMembership,
-    BucketMembership,
-    ContainerRegistryMembership,
-    MachineAccountRole,
-)
-from cpg_infra.abstraction.hailbatch import (
-    HailBatchBillingProject,
-    HailBatchBillingProjectMembership,
-)
+from cpg_infra.abstraction.hailbatch import (HailBatchBillingProject,
+                                             HailBatchBillingProjectMembership)
 from cpg_infra.abstraction.metamist import MetamistProject
-from cpg_infra.config import (
-    CPGDatasetConfig,
-    CPGDatasetComponents,
-    CPGInfrastructureConfig,
-    HailAccount,
-    CPGInfrastructureUser,
-)
+from cpg_infra.config import (CPGDatasetComponents, CPGDatasetConfig,
+                              CPGInfrastructureConfig, CPGInfrastructureUser,
+                              HailAccount)
 from cpg_infra.plugin import get_plugins
 
 SampleMetadataAccessorMembership = namedtuple(
@@ -272,6 +263,7 @@ class CPGInfrastructure:
         self.setup_datasets()
         self.setup_gcp_access_cache_bucket()
         self.setup_gcp_sample_metadata_cloudrun_invoker()
+        self.setup_python_registry()
 
         self.deploy_datasets()
 
@@ -309,7 +301,7 @@ class CPGInfrastructure:
                 if self.config.billing.hail_aggregator_username:
                     HailBatchBillingProjectMembership(
                         infra.get_pulumi_name(
-                            f'batch-billing-member-billing-aggregator'
+                            'batch-billing-member-billing-aggregator'
                         ),
                         billing_project=dataset_cloud_infra.hail_batch_billing_project,
                         user=self.config.billing.hail_aggregator_username,
@@ -500,6 +492,8 @@ class CPGInfrastructure:
                 membership=BucketMembership.READ,
             )
 
+    # endregion ACCESS_CACHE
+
     @cached_property
     def gcp_sample_metadata_invoker_group(self):
         return self.group_provider.create_group(
@@ -517,11 +511,34 @@ class CPGInfrastructure:
             )
 
         infra.add_cloudrun_invoker(
-            f'sample-metadata-cloudrun-invokers',
+            'sample-metadata-cloudrun-invokers',
             service=self.config.sample_metadata.gcp.service_name,
             project=self.config.sample_metadata.gcp.project,
             member=self.gcp_sample_metadata_invoker_group,
         )
+
+    @cached_property
+    def gcp_python_registry(self):
+        """
+        Create a registry for private python packages, we only need one for our org,
+        andt there's no equivalent for Azure.
+
+        """
+        return gcp.artifactregistry.Repository(
+            'python-artifact-registry',
+            repository_id='python-registry',
+            project=self.common_gcp_infra.project.project_id,
+            format='PYTHON',
+            location=self.config.gcp.region,
+            description='Python packages for CPG',
+        )
+
+    def setup_python_registry(self):
+        """
+        Setup the python registry permissions in gcp-common
+        """
+        # force the creation
+        _ = self.gcp_python_registry
 
 
 class CPGDatasetInfrastructure:
@@ -1904,7 +1921,7 @@ class CPGDatasetCloudInfrastructure:
         assert isinstance(self.infra, GcpInfrastructure)
 
         self.root.gcp_sample_metadata_invoker_group.add_member(
-            self.infra.get_pulumi_name(f'sample-metadata-analysis-invoker'),
+            self.infra.get_pulumi_name('sample-metadata-analysis-invoker'),
             self.analysis_group,
         )
         for sm_type, group in self.sample_metadata_groups.items():
@@ -2025,7 +2042,7 @@ class CPGDatasetCloudInfrastructure:
             return
 
         self.infra.add_member_to_container_registry(
-            f'images-reader-in-analysis-runner',
+            'images-reader-in-analysis-runner',
             registry=self.config.analysis_runner.gcp.container_registry_name,
             project=self.config.analysis_runner.gcp.project,
             member=self.images_reader_group,
@@ -2038,11 +2055,11 @@ class CPGDatasetCloudInfrastructure:
         :return:
         """
         self.images_writer_group.add_member(
-            self.infra.get_pulumi_name(f'standard-in-images-writer-group-member'),
+            self.infra.get_pulumi_name('standard-in-images-writer-group-member'),
             self.standard_group,
         )
         self.images_writer_group.add_member(
-            self.infra.get_pulumi_name(f'full-in-images-writer-group-member'),
+            self.infra.get_pulumi_name('full-in-images-writer-group-member'),
             self.full_group,
         )
 
@@ -2065,13 +2082,13 @@ class CPGDatasetCloudInfrastructure:
         custom_container_registry = self.infra.create_container_registry('images')
 
         self.infra.add_member_to_container_registry(
-            f'images-reader-in-container-registry',
+            'images-reader-in-container-registry',
             registry=custom_container_registry,
             member=self.images_reader_group,
             membership=ContainerRegistryMembership.READER,
         )
         self.infra.add_member_to_container_registry(
-            f'images-writer-in-container-registry',
+            'images-writer-in-container-registry',
             registry=custom_container_registry,
             member=self.images_writer_group,
             membership=ContainerRegistryMembership.WRITER,
@@ -2132,7 +2149,7 @@ class CPGDatasetCloudInfrastructure:
     def setup_analysis_runner_access(self):
         assert isinstance(self.infra, GcpInfrastructure)
         self.infra.add_cloudrun_invoker(
-            f'analysis-runner-analysis-invoker',
+            'analysis-runner-analysis-invoker',
             project=self.config.analysis_runner.gcp.project,  # ANALYSIS_RUNNER_PROJECT,
             service=self.config.analysis_runner.gcp.cloud_run_instance_name,  # ANALYSIS_RUNNER_CLOUD_RUN_INSTANCE_NAME,
             member=self.analysis_group,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,6 @@
 [tool.black]
 line-length = 88
 skip-string-normalization = true
+
+[tool.isort]
+py_version = 311

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ google-api-python-client==2.*
 google-auth==2.*
 pulumi-azure-native==1.104.0
 pulumi-azuread==5.40.0
-pulumi-gcp==6.64.0
+pulumi-gcp==6.66.0
 pulumi==3.79.0
 toml-sort
 toml==0.10.2


### PR DESCRIPTION
Use project_id, not the project directly to avoid the `projects/` prefix
+ resort imports