### PR TITLE
Fix lint action error checking

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -11,7 +11,7 @@ jobs:
         shell: bash -l {0}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - uses: actions/setup-python@v4
         with:
@@ -34,7 +34,7 @@ jobs:
           echo "rc=$rc" >> $GITHUB_OUTPUT
 
       - name: "Upload coverage report"
-        uses: codecov/codecov-action@v2
+        uses: codecov/codecov-action@v3
         with:
           files: ./coverage.xml
 

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -43,7 +43,7 @@ jobs:
 
       - name: Fail if tests are not passing
         if: ${{ steps.runtests.outputs.rc != 0 }}
-        uses: actions/github-script@v3
+        uses: actions/github-script@v6
         with:
           script: |
             core.setFailed('Unit tests failed with rc = ${{ steps.runtests.outputs.rc }}')


### PR DESCRIPTION
A later step uses `steps.runtests.outputs.rc` but somewhere along the line that `runtests` id was accidentally removed — or perhaps it was never added. Presumably checking `steps.runtests.outputs.rc` defaults to 0…

(Minor issue found via [actionlint](https://github.com/rhysd/actionlint).)