### PR TITLE
Add partition logic to agg

### DIFF
--- a/cpg_infra/billing_aggregator/aggregate/gcp.py
+++ b/cpg_infra/billing_aggregator/aggregate/gcp.py
@@ -132,15 +132,14 @@ def get_billing_data(start: datetime, end: datetime):
             currency, currency_conversion_rate, usage, credits,
             invoice, cost_type, adjustment_info
         FROM `{utils.GCP_BILLING_BQ_TABLE}`
-        WHERE export_time >= @start
-            AND export_time <= @end
+        WHERE _PARTITIONDATE BETWEEN @start AND @end
             AND project.id NOT IN UNNEST(@exclude)
     """
     exclude_projects = [utils.SEQR_PROJECT_ID, utils.ES_INDEX_PROJECT_ID]
     job_config = bq.QueryJobConfig(
         query_parameters=[
-            bq.ScalarQueryParameter('start', 'STRING', str(start)),
-            bq.ScalarQueryParameter('end', 'STRING', str(end)),
+            bq.ScalarQueryParameter('start', 'DATE', start),
+            bq.ScalarQueryParameter('end', 'DATE', end),
             bq.ArrayQueryParameter('exclude', 'STRING', exclude_projects),
         ]
     )

--- a/cpg_infra/billing_aggregator/aggregate/gcp.py
+++ b/cpg_infra/billing_aggregator/aggregate/gcp.py
@@ -132,7 +132,7 @@ def get_billing_data(start: datetime, end: datetime):
             currency, currency_conversion_rate, usage, credits,
             invoice, cost_type, adjustment_info
         FROM `{utils.GCP_BILLING_BQ_TABLE}`
-        WHERE DAY_TRUNC(usage_end_time, DAY) BETWEEN @start AND @end
+        WHERE DATE_TRUNC(usage_end_time, DAY) BETWEEN @start AND @end
             AND project.id NOT IN UNNEST(@exclude)
     """
     exclude_projects = [utils.SEQR_PROJECT_ID, utils.ES_INDEX_PROJECT_ID]

--- a/cpg_infra/billing_aggregator/aggregate/gcp.py
+++ b/cpg_infra/billing_aggregator/aggregate/gcp.py
@@ -132,7 +132,7 @@ def get_billing_data(start: datetime, end: datetime):
             currency, currency_conversion_rate, usage, credits,
             invoice, cost_type, adjustment_info
         FROM `{utils.GCP_BILLING_BQ_TABLE}`
-        WHERE _PARTITIONDATE BETWEEN @start AND @end
+        WHERE DAY_TRUNC(usage_end_time, DAY) BETWEEN @start AND @end
             AND project.id NOT IN UNNEST(@exclude)
     """
     exclude_projects = [utils.SEQR_PROJECT_ID, utils.ES_INDEX_PROJECT_ID]

--- a/cpg_infra/billing_aggregator/aggregate/seqr.py
+++ b/cpg_infra/billing_aggregator/aggregate/seqr.py
@@ -425,7 +425,11 @@ def migrate_entries_from_bq(
             result += len(entries)
         elif mode == 'prod':
             result += utils.upsert_rows_into_bigquery(
-                table=utils.GCP_AGGREGATE_DEST_TABLE, objs=entries, dry_run=False
+                table=utils.GCP_AGGREGATE_DEST_TABLE,
+                objs=entries,
+                dry_run=False,
+                window_start=istart,
+                window_end=iend,
             )
         elif mode == 'local':
             if not os.path.exists(output_path):

--- a/cpg_infra/billing_aggregator/aggregate/seqr.py
+++ b/cpg_infra/billing_aggregator/aggregate/seqr.py
@@ -326,7 +326,7 @@ def migrate_entries_from_bq(
             location, export_time, cost, currency, currency_conversion_rate, usage,
             credits, invoice, cost_type, adjustment_info
         FROM `{GCP_BILLING_BQ_TABLE}`
-        WHERE _PARTITIONDATE BETWEEN @start AND @end
+        WHERE DAY_TRUNC(usage_end_time, DAY) BETWEEN @start AND @end
             AND project.id IN UNNEST(@projects)
         ORDER BY usage_start_time
     """

--- a/cpg_infra/billing_aggregator/aggregate/seqr.py
+++ b/cpg_infra/billing_aggregator/aggregate/seqr.py
@@ -326,7 +326,7 @@ def migrate_entries_from_bq(
             location, export_time, cost, currency, currency_conversion_rate, usage,
             credits, invoice, cost_type, adjustment_info
         FROM `{GCP_BILLING_BQ_TABLE}`
-        WHERE DAY_TRUNC(usage_end_time, DAY) BETWEEN @start AND @end
+        WHERE DATE_TRUNC(usage_end_time, DAY) BETWEEN @start AND @end
             AND project.id IN UNNEST(@projects)
         ORDER BY usage_start_time
     """

--- a/cpg_infra/billing_aggregator/aggregate/seqr.py
+++ b/cpg_infra/billing_aggregator/aggregate/seqr.py
@@ -326,8 +326,7 @@ def migrate_entries_from_bq(
             location, export_time, cost, currency, currency_conversion_rate, usage,
             credits, invoice, cost_type, adjustment_info
         FROM `{GCP_BILLING_BQ_TABLE}`
-        WHERE export_time >= @start
-            AND export_time <= @end
+        WHERE _PARTITIONDATE BETWEEN @start AND @end
             AND project.id IN UNNEST(@projects)
         ORDER BY usage_start_time
     """
@@ -335,8 +334,8 @@ def migrate_entries_from_bq(
     projects = [utils.SEQR_PROJECT_ID, utils.ES_INDEX_PROJECT_ID]
     job_config = bq.QueryJobConfig(
         query_parameters=[
-            bq.ScalarQueryParameter('start', 'STRING', str(istart)),
-            bq.ScalarQueryParameter('end', 'STRING', str(iend)),
+            bq.ScalarQueryParameter('start', 'DATE', istart),
+            bq.ScalarQueryParameter('end', 'DATE', iend),
             bq.ArrayQueryParameter('projects', 'STRING', projects),
         ]
     )

--- a/cpg_infra/billing_aggregator/aggregate/utils.py
+++ b/cpg_infra/billing_aggregator/aggregate/utils.py
@@ -1053,7 +1053,7 @@ def get_invoice_month_range(convert_month: date) -> tuple[date, date]:
 
     # Grab the last day of invoice month then add INVOICE_DAY_DIFF days
     last_day = (
-        first_day.replace(month=(convert_month.month + 1) % 12)
+        first_day.replace(month=(convert_month.month % 12) + 1)
         + timedelta(days=-1)
         + timedelta(days=INVOICE_DAY_DIFF)
     )

--- a/cpg_infra/billing_aggregator/aggregate/utils.py
+++ b/cpg_infra/billing_aggregator/aggregate/utils.py
@@ -637,7 +637,7 @@ def upsert_rows_into_bigquery(
         _query = f"""
             SELECT id FROM `{table}`
             WHERE id IN UNNEST(@ids)
-            AND DAY_TRUNC(usage_end_time, DAY) BETWEEN @window_start AND @window_end;
+            AND DATE_TRUNC(usage_end_time, DAY) BETWEEN @window_start AND @window_end;
         """
 
         # NOTE: it's possible to have valid duplicate rows
@@ -728,7 +728,7 @@ def upsert_aggregated_dataframe_into_bigquery(
     _query = f"""
         SELECT id FROM {table}
         WHERE id IN UNNEST(@ids);
-        AND DAY_TRUNC(usage_end_time, DAY) BETWEEN @window_start AND @window_end;
+        AND DATE_TRUNC(usage_end_time, DAY) BETWEEN @window_start AND @window_end;
     """
     job_config = bq.QueryJobConfig(
         query_parameters=[
@@ -783,7 +783,7 @@ def get_currency_conversion_rate_for_time(time: datetime):
             SELECT currency_conversion_rate
             FROM {GCP_BILLING_BQ_TABLE}
             WHERE invoice.month = @invoice_month
-            AND DAY_TRUNC(usage_end_time, DAY) BETWEEN @window_start AND @window_end;
+            AND DATE_TRUNC(usage_end_time, DAY) BETWEEN @window_start AND @window_end;
             LIMIT 1
         """
         job_config = bq.QueryJobConfig(

--- a/cpg_infra/billing_aggregator/aggregate/utils.py
+++ b/cpg_infra/billing_aggregator/aggregate/utils.py
@@ -648,8 +648,8 @@ def upsert_rows_into_bigquery(
         job_config = bq.QueryJobConfig(
             query_parameters=[
                 bq.ArrayQueryParameter('ids', 'STRING', list(ids)),
-                bq.ScalarQueryParameter('window_start', 'DATE', date(window_start)),
-                bq.ScalarQueryParameter('window_end', 'DATE', date(window_end)),
+                bq.ScalarQueryParameter('window_start', 'DATE', window_start),
+                bq.ScalarQueryParameter('window_end', 'DATE', window_end),
             ]
         )
 
@@ -733,8 +733,8 @@ def upsert_aggregated_dataframe_into_bigquery(
     job_config = bq.QueryJobConfig(
         query_parameters=[
             bq.ArrayQueryParameter('ids', 'STRING', list(set(df['id']))),
-            bq.ScalarQueryParameter('window_start', 'DATE', date(window_start)),
-            bq.ScalarQueryParameter('window_end', 'DATE', date(window_end)),
+            bq.ScalarQueryParameter('window_start', 'DATE', window_start),
+            bq.ScalarQueryParameter('window_end', 'DATE', window_end),
         ]
     )
 
@@ -789,8 +789,8 @@ def get_currency_conversion_rate_for_time(time: datetime):
         job_config = bq.QueryJobConfig(
             query_parameters=[
                 bq.ScalarQueryParameter('invoice_month', 'STRING', key),
-                bq.ScalarQueryParameter('window_start', 'DATE', date(window_start)),
-                bq.ScalarQueryParameter('window_end', 'DATE', date(window_end)),
+                bq.ScalarQueryParameter('window_start', 'DATE', window_start),
+                bq.ScalarQueryParameter('window_end', 'DATE', window_end),
             ]
         )
         query_result = (
@@ -1060,10 +1060,6 @@ def get_invoice_month_range(convert_month: date) -> tuple[date, date]:
         next_month = first_day.replace(month=convert_month.month + 1)
 
     # Grab the last day of invoice month then add INVOICE_DAY_DIFF days
-    last_day = (
-        next_month
-        + timedelta(days=-1)
-        + timedelta(days=INVOICE_DAY_DIFF)
-    )
+    last_day = next_month + timedelta(days=-1) + timedelta(days=INVOICE_DAY_DIFF)
 
     return start_day, last_day

--- a/cpg_infra/billing_aggregator/aggregate/utils.py
+++ b/cpg_infra/billing_aggregator/aggregate/utils.py
@@ -711,8 +711,8 @@ def upsert_rows_into_bigquery(
 def upsert_aggregated_dataframe_into_bigquery(
     df: pd.DataFrame,
     table: str = GCP_AGGREGATE_DEST_TABLE,
-    window_start: datetime=None,
-    window_end: datetime=None
+    window_start: datetime = None,
+    window_end: datetime = None,
 ):
     """
     Upsert rows from a dataframe into the BQ.aggregate table.
@@ -793,7 +793,9 @@ def get_currency_conversion_rate_for_time(time: datetime):
                 bq.ScalarQueryParameter('window_end', 'DATE', date(window_end)),
             ]
         )
-        query_result = get_bigquery_client().query(query, job_config=job_config).result()
+        query_result = (
+            get_bigquery_client().query(query, job_config=job_config).result()
+        )
 
         if query_result.total_rows == 0:
             raise ValueError(
@@ -1044,6 +1046,7 @@ def get_hail_entry(
         'adjustment_info': None,
     }
 
+
 def get_invoice_month_range(convert_month: date) -> tuple[date, date]:
     """Get the start and end date of the invoice month for a given date"""
     first_day = convert_month.replace(day=1)
@@ -1051,9 +1054,14 @@ def get_invoice_month_range(convert_month: date) -> tuple[date, date]:
     # Grab the first day of invoice month then subtract INVOICE_DAY_DIFF days
     start_day = first_day + timedelta(days=-INVOICE_DAY_DIFF)
 
+    if convert_month.month == 12:
+        next_month = first_day.replace(month=1, year=convert_month.year + 1)
+    else:
+        next_month = first_day.replace(month=convert_month.month + 1)
+
     # Grab the last day of invoice month then add INVOICE_DAY_DIFF days
     last_day = (
-        first_day.replace(month=(convert_month.month % 12) + 1)
+        next_month
         + timedelta(days=-1)
         + timedelta(days=INVOICE_DAY_DIFF)
     )

--- a/cpg_infra/billing_aggregator/aggregate/utils.py
+++ b/cpg_infra/billing_aggregator/aggregate/utils.py
@@ -54,6 +54,8 @@ T = TypeVar('T')
 
 DEFAULT_TOPIC = 'admin'
 
+INVOICE_DAY_DIFF = 3
+
 GCP_PROJECT = os.getenv('BILLING_PROJECT_ID')
 GCP_BILLING_BQ_TABLE = os.getenv('GCP_BILLING_SOURCE_TABLE')
 GCP_AGGREGATE_DEST_TABLE = os.getenv('GCP_AGGREGATE_DEST_TABLE')
@@ -582,6 +584,8 @@ def billing_row_to_topic(row, dataset_to_gcp_map: dict) -> str | None:
 
 
 def upsert_rows_into_bigquery(
+    window_start: datetime,
+    window_end: datetime,
     objs: list[dict[str, Any]],
     dry_run: bool,
     table: str = GCP_AGGREGATE_DEST_TABLE,
@@ -599,6 +603,11 @@ def upsert_rows_into_bigquery(
     It has some optimisations about max insert size, so this should be
     able to take an arbitrary amount of rows.
     """
+
+    if not window_start or not window_end:
+        raise ValueError('window_start and window_end must be defined')
+    elif window_start > window_end:
+        raise ValueError('window_start must be before window_end')
 
     if not objs:
         logger.info('Not inserting any rows')
@@ -627,7 +636,8 @@ def upsert_rows_into_bigquery(
     for chunk_idx, chunked_objs in enumerate(chunk(objs, chunk_size)):
         _query = f"""
             SELECT id FROM `{table}`
-            WHERE id IN UNNEST(@ids);
+            WHERE id IN UNNEST(@ids)
+            AND _PARTITIONDATE BETWEEN @window_start AND @window_end;
         """
 
         # NOTE: it's possible to have valid duplicate rows
@@ -638,6 +648,8 @@ def upsert_rows_into_bigquery(
         job_config = bq.QueryJobConfig(
             query_parameters=[
                 bq.ArrayQueryParameter('ids', 'STRING', list(ids)),
+                bq.ScalarQueryParameter('window_start', 'DATE', date(window_start)),
+                bq.ScalarQueryParameter('window_end', 'DATE', date(window_end)),
             ]
         )
 
@@ -697,7 +709,10 @@ def upsert_rows_into_bigquery(
 
 
 def upsert_aggregated_dataframe_into_bigquery(
-    df: pd.DataFrame, table: str = GCP_AGGREGATE_DEST_TABLE
+    df: pd.DataFrame,
+    table: str = GCP_AGGREGATE_DEST_TABLE,
+    window_start: datetime=None,
+    window_end: datetime=None
 ):
     """
     Upsert rows from a dataframe into the BQ.aggregate table.
@@ -713,10 +728,13 @@ def upsert_aggregated_dataframe_into_bigquery(
     _query = f"""
         SELECT id FROM {table}
         WHERE id IN UNNEST(@ids);
+        AND _PARTITIONDATE BETWEEN @window_start AND @window_end;
     """
     job_config = bq.QueryJobConfig(
         query_parameters=[
             bq.ArrayQueryParameter('ids', 'STRING', list(set(df['id']))),
+            bq.ScalarQueryParameter('window_start', 'DATE', date(window_start)),
+            bq.ScalarQueryParameter('window_end', 'DATE', date(window_end)),
         ]
     )
 
@@ -756,16 +774,26 @@ def get_currency_conversion_rate_for_time(time: datetime):
     the job finishes.
     """
 
+    window_start, window_end = get_invoice_month_range(time)
+
     key = f'{time.year}{str(time.month).zfill(2)}'
     if key not in CACHED_CURRENCY_CONVERSION:
         logger.info(f'Looking up currency conversion rate for {key}')
         query = f"""
             SELECT currency_conversion_rate
             FROM {GCP_BILLING_BQ_TABLE}
-            WHERE invoice.month = "{key}"
+            WHERE invoice.month = @invoice_month
+            AND _PARTITIONDATE BETWEEN @window_start AND @window_end;
             LIMIT 1
         """
-        query_result = get_bigquery_client().query(query).result()
+        job_config = bq.QueryJobConfig(
+            query_parameters=[
+                bq.ScalarQueryParameter('invoice_month', 'STRING', key),
+                bq.ScalarQueryParameter('window_start', 'DATE', date(window_start)),
+                bq.ScalarQueryParameter('window_end', 'DATE', date(window_end)),
+            ]
+        )
+        query_result = get_bigquery_client().query(query, job_config=job_config).result()
 
         if query_result.total_rows == 0:
             raise ValueError(
@@ -1015,3 +1043,19 @@ def get_hail_entry(
         'cost_type': 'regular',
         'adjustment_info': None,
     }
+
+def get_invoice_month_range(convert_month: date) -> tuple[date, date]:
+    """Get the start and end date of the invoice month for a given date"""
+    first_day = convert_month.replace(day=1)
+
+    # Grab the first day of invoice month then subtract INVOICE_DAY_DIFF days
+    start_day = first_day + timedelta(days=-INVOICE_DAY_DIFF)
+
+    # Grab the last day of invoice month then add INVOICE_DAY_DIFF days
+    last_day = (
+        first_day.replace(month=(convert_month.month + 1) % 12)
+        + timedelta(days=-1)
+        + timedelta(days=INVOICE_DAY_DIFF)
+    )
+
+    return start_day, last_day

--- a/cpg_infra/billing_aggregator/aggregate/utils.py
+++ b/cpg_infra/billing_aggregator/aggregate/utils.py
@@ -637,7 +637,7 @@ def upsert_rows_into_bigquery(
         _query = f"""
             SELECT id FROM `{table}`
             WHERE id IN UNNEST(@ids)
-            AND _PARTITIONDATE BETWEEN @window_start AND @window_end;
+            AND DAY_TRUNC(usage_end_time, DAY) BETWEEN @window_start AND @window_end;
         """
 
         # NOTE: it's possible to have valid duplicate rows
@@ -728,7 +728,7 @@ def upsert_aggregated_dataframe_into_bigquery(
     _query = f"""
         SELECT id FROM {table}
         WHERE id IN UNNEST(@ids);
-        AND _PARTITIONDATE BETWEEN @window_start AND @window_end;
+        AND DAY_TRUNC(usage_end_time, DAY) BETWEEN @window_start AND @window_end;
     """
     job_config = bq.QueryJobConfig(
         query_parameters=[
@@ -783,7 +783,7 @@ def get_currency_conversion_rate_for_time(time: datetime):
             SELECT currency_conversion_rate
             FROM {GCP_BILLING_BQ_TABLE}
             WHERE invoice.month = @invoice_month
-            AND _PARTITIONDATE BETWEEN @window_start AND @window_end;
+            AND DAY_TRUNC(usage_end_time, DAY) BETWEEN @window_start AND @window_end;
             LIMIT 1
         """
         job_config = bq.QueryJobConfig(

--- a/cpg_infra/billing_aggregator/monthly_aggregate/main.py
+++ b/cpg_infra/billing_aggregator/monthly_aggregate/main.py
@@ -209,7 +209,7 @@ def get_billing_data(invoice_month: str) -> DataFrame:
     _query = f"""
         SELECT * FROM `{GCP_MONTHLY_BILLING_BQ_TABLE}`
         WHERE month = @invoice_month
-        AND DAY_TRUNC(usage_end_time, DAY) BETWEEN @window_start AND @window_end
+        AND DATE_TRUNC(usage_end_time, DAY) BETWEEN @window_start AND @window_end
         ORDER BY topic
     """
     job_config = bq.QueryJobConfig(

--- a/cpg_infra/billing_aggregator/monthly_aggregate/main.py
+++ b/cpg_infra/billing_aggregator/monthly_aggregate/main.py
@@ -193,13 +193,10 @@ def get_invoice_month_range(convert_month: date) -> tuple[date, date]:
         next_month = first_day.replace(month=convert_month.month + 1)
 
     # Grab the last day of invoice month then add INVOICE_DAY_DIFF days
-    last_day = (
-        next_month
-        + timedelta(days=-1)
-        + timedelta(days=INVOICE_DAY_DIFF)
-    )
+    last_day = next_month + timedelta(days=-1) + timedelta(days=INVOICE_DAY_DIFF)
 
     return start_day, last_day
+
 
 def get_billing_data(invoice_month: str) -> DataFrame:
     """
@@ -207,7 +204,8 @@ def get_billing_data(invoice_month: str) -> DataFrame:
     Return results as a dataframe
     """
 
-    window_start, window_end = get_invoice_month_range(invoice_month)
+    invoice_month_date = datetime.strptime(invoice_month, '%Y%m').date()
+    window_start, window_end = get_invoice_month_range(invoice_month_date)
     _query = f"""
         SELECT * FROM `{GCP_MONTHLY_BILLING_BQ_TABLE}`
         WHERE month = @invoice_month

--- a/cpg_infra/billing_aggregator/monthly_aggregate/main.py
+++ b/cpg_infra/billing_aggregator/monthly_aggregate/main.py
@@ -189,7 +189,7 @@ def get_invoice_month_range(convert_month: date) -> tuple[date, date]:
 
     # Grab the last day of invoice month then add INVOICE_DAY_DIFF days
     last_day = (
-        first_day.replace(month=(convert_month.month + 1) % 12)
+        first_day.replace(month=(convert_month.month % 12) + 1)
         + timedelta(days=-1)
         + timedelta(days=INVOICE_DAY_DIFF)
     )

--- a/cpg_infra/billing_aggregator/monthly_aggregate/main.py
+++ b/cpg_infra/billing_aggregator/monthly_aggregate/main.py
@@ -209,7 +209,7 @@ def get_billing_data(invoice_month: str) -> DataFrame:
     _query = f"""
         SELECT * FROM `{GCP_MONTHLY_BILLING_BQ_TABLE}`
         WHERE month = @invoice_month
-        AND _PARTITIONDATE BETWEEN @window_start AND @window_end
+        AND DAY_TRUNC(usage_end_time, DAY) BETWEEN @window_start AND @window_end
         ORDER BY topic
     """
     job_config = bq.QueryJobConfig(

--- a/cpg_infra/billing_aggregator/monthly_aggregate/main.py
+++ b/cpg_infra/billing_aggregator/monthly_aggregate/main.py
@@ -199,13 +199,6 @@ def get_invoice_month_range(convert_month: date) -> tuple[date, date]:
         + timedelta(days=INVOICE_DAY_DIFF)
     )
 
-    # Grab the last day of invoice month then add INVOICE_DAY_DIFF days
-    last_day = (
-        first_day.replace(month=(convert_month.month % 12) + 1)
-        + timedelta(days=-1)
-        + timedelta(days=INVOICE_DAY_DIFF)
-    )
-
     return start_day, last_day
 
 def get_billing_data(invoice_month: str) -> DataFrame:

--- a/cpg_infra/billing_aggregator/monthly_aggregate/main.py
+++ b/cpg_infra/billing_aggregator/monthly_aggregate/main.py
@@ -187,6 +187,18 @@ def get_invoice_month_range(convert_month: date) -> tuple[date, date]:
     # Grab the first day of invoice month then subtract INVOICE_DAY_DIFF days
     start_day = first_day + timedelta(days=-INVOICE_DAY_DIFF)
 
+    if convert_month.month == 12:
+        next_month = first_day.replace(month=1, year=convert_month.year + 1)
+    else:
+        next_month = first_day.replace(month=convert_month.month + 1)
+
+    # Grab the last day of invoice month then add INVOICE_DAY_DIFF days
+    last_day = (
+        next_month
+        + timedelta(days=-1)
+        + timedelta(days=INVOICE_DAY_DIFF)
+    )
+
     # Grab the last day of invoice month then add INVOICE_DAY_DIFF days
     last_day = (
         first_day.replace(month=(convert_month.month % 12) + 1)

--- a/cpg_infra/billing_aggregator/monthly_aggregate/main.py
+++ b/cpg_infra/billing_aggregator/monthly_aggregate/main.py
@@ -1,14 +1,15 @@
 # pylint: disable=import-error,no-name-in-module,unused-argument
 """A Cloud Function to update the status of genomic samples."""
 
+import os
 import json
 import asyncio
 import logging
-import os
+
 from functools import cache
 from base64 import b64decode
 
-from datetime import datetime
+from datetime import datetime, timedelta, date
 
 import functions_framework
 import google.auth
@@ -19,7 +20,7 @@ from googleapiclient.errors import HttpError
 from flask import abort, Response, Request
 from pandas import DataFrame
 
-
+INVOICE_DAY_DIFF = 3
 OUTPUT_GOOGLE_SHEET = os.getenv('OUTPUT_BILLING_SHEET')
 GCP_MONTHLY_BILLING_BQ_TABLE = os.getenv('BQ_MONTHLY_SUMMARY_TABLE')
 
@@ -179,20 +180,40 @@ def append_values_to_google_sheet(spreadsheet_id, _values, invoice_month):
         return error
 
 
+def get_invoice_month_range(convert_month: date) -> tuple[date, date]:
+    """Get the start and end date of the invoice month for a given date"""
+    first_day = convert_month.replace(day=1)
+
+    # Grab the first day of invoice month then subtract INVOICE_DAY_DIFF days
+    start_day = first_day + timedelta(days=-INVOICE_DAY_DIFF)
+
+    # Grab the last day of invoice month then add INVOICE_DAY_DIFF days
+    last_day = (
+        first_day.replace(month=(convert_month.month + 1) % 12)
+        + timedelta(days=-1)
+        + timedelta(days=INVOICE_DAY_DIFF)
+    )
+
+    return start_day, last_day
+
 def get_billing_data(invoice_month: str) -> DataFrame:
     """
     Retrieve the billing data for a particular billing month from the aggregation table
     Return results as a dataframe
     """
 
+    window_start, window_end = get_invoice_month_range(invoice_month)
     _query = f"""
         SELECT * FROM `{GCP_MONTHLY_BILLING_BQ_TABLE}`
-        WHERE month = @yearmonth
+        WHERE month = @invoice_month
+        AND _PARTITIONDATE BETWEEN @window_start AND @window_end
         ORDER BY topic
     """
     job_config = bq.QueryJobConfig(
         query_parameters=[
-            bq.ScalarQueryParameter('yearmonth', 'STRING', str(invoice_month)),
+            bq.ScalarQueryParameter('invoice_month', 'STRING', str(invoice_month)),
+            bq.ScalarQueryParameter('window_start', 'DATE', window_start),
+            bq.ScalarQueryParameter('window_end', 'DATE', window_end),
         ]
     )
 


### PR DESCRIPTION
Using the property _PARTITIONDATE to query our billing tables to increase efficiency.

NOTE: This WILL NOT WORK AS INTENDED until the table is partitioned. This will be imminent.
It's also worth noting that the bigquery keyword BETWEEN is date inclusive of the start and end.