### PR TITLE
Seqr BQ billing data should use prop map by usage_end_time

### DIFF
--- a/cpg_infra/billing_aggregator/aggregate/seqr.py
+++ b/cpg_infra/billing_aggregator/aggregate/seqr.py
@@ -375,6 +375,9 @@ def migrate_entries_from_bq(
             usage_start_time = utils.get_date_time_from_value(
                 'usage_start_time', obj['usage_start_time']
             )
+            usage_end_time = utils.get_date_time_from_value(
+                'usage_end_time', obj['usage_end_time']
+            )
             dates = ['usage_start_time', 'usage_end_time', 'export_time']
             for k in dates:
                 obj[k] = utils.to_bq_time(utils.get_date_time_from_value(k, obj[k]))
@@ -385,7 +388,7 @@ def migrate_entries_from_bq(
                 param_map = {'seqr': (1.0, 1)}
             elif current_date is None or usage_start_time.date() > current_date:
                 current_date, param_map = get_ratios_from_date(
-                    dt=usage_start_time.date(), prop_map=prop_map
+                    dt=usage_end_time.date(), prop_map=prop_map
                 )
 
             # Data transforms and key changes

--- a/cpg_infra/driver.py
+++ b/cpg_infra/driver.py
@@ -785,7 +785,7 @@ class CPGDatasetCloudInfrastructure:
             for access_level, machine_account in values:
                 yield kind, access_level, machine_account
 
-    def working_machine_accounts_by_access_level(self):
+    def working_machine_accounts_by_access_level(self) -> dict[AccessLevel, list[Any]]:
         machine_accounts: dict[AccessLevel, list[Any]] = defaultdict(list)
         for _, values in self.working_machine_accounts_by_type.items():
             for access_level, machine_account in values:


### PR DESCRIPTION
This is a reasonably appropriate fix for the problem, it's a max 24 hour difference, and our timing for updating analysis is basically within that tolerance.