### PR TITLE
Persist metamist members to state, so we stop rerunning

### DIFF
--- a/cpg_infra/abstraction/metamist.py
+++ b/cpg_infra/abstraction/metamist.py
@@ -117,7 +117,7 @@ class MetamistProjectMembersProvider(pulumi.dynamic.ResourceProvider):
 
         return pulumi.dynamic.CreateResult(
             id_=f'metamist-project-members::{project_name}',
-            outs={},
+            outs={**props},
         )
 
     def diff(self, _id: str, _olds, _news) -> pulumi.dynamic.DiffResult:


### PR DESCRIPTION
We're rerunning that metamist call a lot of times because it's not persisting the members into state, to check on next load.
The members are ordered earlier, so list comparison is fine here.