### PR TITLE
Support missing buckets in storage_visualisation bot

### DIFF
--- a/storage_visualization/treemap.py
+++ b/storage_visualization/treemap.py
@@ -78,13 +78,13 @@ def form_row(name: str, parent: str, values: dict[str, Any]) -> tuple:
     )
 
 
-def main():
+def main() -> None:
     """Main entrypoint."""
 
     logging.getLogger().setLevel(logging.INFO)
     args = get_parser().parse_args()
 
-    rows: dict[tuple] = []
+    rows: list[tuple] = []
 
     root_values = defaultdict(int)
     group_by_dataset = args.group_by_dataset

--- a/storage_visualization/treemap.py
+++ b/storage_visualization/treemap.py
@@ -86,7 +86,7 @@ def main() -> None:
 
     rows: list[tuple] = []
 
-    root_values = defaultdict(int)
+    root_values: dict[str, int] = defaultdict(int)
     group_by_dataset = args.group_by_dataset
     datasets: dict[str, dict[str, int]] = defaultdict(lambda: defaultdict(int))
     for input_path in args.input:


### PR DESCRIPTION
The storage visualisation bot is failing because we don't require all buckets with the prefix to exist. A potentially more clean approach would be to look at the storage section in the config, and iterate through the listed buckets, rather than look at the prefix - but that's for another time.

Failing job: https://batch.hail.populationgenomics.org.au/batches/433223/jobs/57

```
Traceback (most recent call last):
  File "/cpg-infrastructure/storage_visualization/disk_usage.py", line 110, in <module>
    main()
  File "/cpg-infrastructure/storage_visualization/disk_usage.py", line 82, in main
    for blob in blobs:
  File "/usr/local/lib/python3.10/site-packages/google/api_core/page_iterator.py", line 208, in _items_iter
    for page in self._page_iter(increment=False):
  File "/usr/local/lib/python3.10/site-packages/google/api_core/page_iterator.py", line 244, in _page_iter
    page = self._next_page()
  File "/usr/local/lib/python3.10/site-packages/google/api_core/page_iterator.py", line 373, in _next_page
    response = self._get_next_page_response()
  File "/usr/local/lib/python3.10/site-packages/google/api_core/page_iterator.py", line 432, in _get_next_page_response
    return self.api_request(
  File "/usr/local/lib/python3.10/site-packages/google/cloud/storage/_http.py", line 72, in api_request
    return call()
  File "/usr/local/lib/python3.10/site-packages/google/api_core/retry.py", line 372, in retry_wrapped_func
    return retry_target(
  File "/usr/local/lib/python3.10/site-packages/google/api_core/retry.py", line 207, in retry_target
    result = target()
  File "/usr/local/lib/python3.10/site-packages/google/cloud/_http/__init__.py", line 494, in api_request
    raise exceptions.from_http_response(response)
google.api_core.exceptions.NotFound: 404 GET https://storage.googleapis.com/storage/v1/b/cpg-<dataset>-test/o?projection=noAcl&prettyPrint=false: The specified bucket does not exist.
```