### PR TITLE
Improve memory efficiency of billing aggregators

### DIFF
--- a/cpg_infra/billing_aggregator/aggregate/hail.py
+++ b/cpg_infra/billing_aggregator/aggregate/hail.py
@@ -232,7 +232,7 @@ if __name__ == '__main__':
     logging.getLogger('asyncio').setLevel(logging.ERROR)
     logging.getLogger('urllib3').setLevel(logging.WARNING)
 
-    test_start, test_end = datetime(2024, 2, 1), None
+    test_start, test_end = datetime(2024, 2, 14), None
     asyncio.new_event_loop().run_until_complete(
         main(
             start=test_start,

--- a/cpg_infra/billing_aggregator/aggregate/seqr.py
+++ b/cpg_infra/billing_aggregator/aggregate/seqr.py
@@ -81,7 +81,8 @@ aapi = AnalysisApi()
 
 
 def get_finalised_entries_for_batch(
-    batch,
+    batch: utils.BatchType,
+    jobs: list[utils.JobType],
     proportion_map: ProportionateMapType,
 ) -> Generator[dict[str, Any], None, None]:
     """
@@ -107,9 +108,9 @@ def get_finalised_entries_for_batch(
 
     currency_conversion_rate = utils.get_currency_conversion_rate_for_time(start_time)
 
-    jobs_with_no_dataset: list[dict[str, Any]] = []
+    jobs_with_no_dataset: list[utils.JobType] = []
 
-    for job in batch['jobs']:
+    for job in jobs:
         dataset = job['attributes'].get('dataset', '').replace('-test', '')
         if not dataset:
             jobs_with_no_dataset.append(job)
@@ -249,7 +250,7 @@ def get_finalised_entries_for_dataset_batch_and_job(
     batch_start_time: datetime,
     batch_end_time: datetime,
     namespace: str | None,
-    job: dict[str, Any],
+    job: utils.JobType,
     currency_conversion_rate: float,
     ar_guid: str | None,
 ) -> Generator[dict[str, Any], None, None]:
@@ -676,9 +677,13 @@ async def main(
 
         return batches
 
-    def func_get_finalised_entries(batch) -> Generator[dict[str, Any], None, None]:
+    def func_get_finalised_entries(
+        batch: utils.BatchType,
+        jobs: list[utils.JobType],
+    ) -> Generator[dict[str, Any], None, None]:
         return get_finalised_entries_for_batch(
             batch=batch,
+            jobs=jobs,
             proportion_map=prop_maps.shared_computation_prop_map,
         )
 

--- a/cpg_infra/billing_aggregator/aggregate/seqr.py
+++ b/cpg_infra/billing_aggregator/aggregate/seqr.py
@@ -34,7 +34,7 @@ import hashlib
 import logging
 import os
 import shutil
-from datetime import date, datetime
+from datetime import date, datetime, timezone
 from typing import Any, Generator, Literal
 
 import functions_framework
@@ -194,7 +194,7 @@ def get_finalised_entries_for_batch(
                 # from 2023-01-01 onwards. We've migrated that data, so we're good to go.
 
                 key_components: tuple[str, ...]
-                if start_time < datetime(2023, 1, 1):
+                if start_time < datetime(2023, 1, 1).astimezone(timezone.utc):
                     key_components = (
                         SERVICE_ID,
                         'distributed',

--- a/cpg_infra/billing_aggregator/aggregate/seqr.py
+++ b/cpg_infra/billing_aggregator/aggregate/seqr.py
@@ -83,7 +83,7 @@ aapi = AnalysisApi()
 def get_finalised_entries_for_batch(
     batch,
     proportion_map: ProportionateMapType,
-) -> list[dict[str, Any]]:
+) -> Generator[dict[str, Any], None, None]:
     """
     Take a batch dictionary, and the full proportion map
     and return a list of entries for the Hail batch.
@@ -108,7 +108,6 @@ def get_finalised_entries_for_batch(
     currency_conversion_rate = utils.get_currency_conversion_rate_for_time(start_time)
 
     jobs_with_no_dataset: list[dict[str, Any]] = []
-    entries: list[dict[str, Any]] = []
 
     for job in batch['jobs']:
         dataset = job['attributes'].get('dataset', '').replace('-test', '')
@@ -116,19 +115,23 @@ def get_finalised_entries_for_batch(
             jobs_with_no_dataset.append(job)
             continue
 
-        entries.extend(
-            get_finalised_entries_for_dataset_batch_and_job(
-                dataset=dataset,
-                batch_id=batch_id,
-                batch_name=batch_name,
-                batch_start_time=start_time,
-                batch_end_time=end_time,
-                namespace=namespace,
-                job=job,
-                ar_guid=ar_guid,
-                currency_conversion_rate=currency_conversion_rate,
-            ),
-        )
+        for entry in get_finalised_entries_for_dataset_batch_and_job(
+            dataset=dataset,
+            batch_id=batch_id,
+            batch_name=batch_name,
+            batch_start_time=start_time,
+            batch_end_time=end_time,
+            namespace=namespace,
+            job=job,
+            ar_guid=ar_guid,
+            currency_conversion_rate=currency_conversion_rate,
+        ):
+            yield entry
+            yield utils.get_credit(
+                entry=entry,
+                topic='seqr',
+                project=utils.SEQR_PROJECT_FIELD,
+            )
 
     # Now go through each job within the batch withOUT a dataset
     # and proportion a fraction of them to each relevant dataset.
@@ -212,37 +215,31 @@ def get_finalised_entries_for_batch(
                         batch_resource,
                     )
                 key = '-'.join(key_components).replace('/', '-')
-                entries.append(
-                    utils.get_hail_entry(
-                        key=key,
-                        topic=dataset,
-                        service_id=SERVICE_ID,
-                        description='Seqr compute (distributed)',
-                        cost=gross_cost * fraction,
-                        currency_conversion_rate=currency_conversion_rate,
-                        usage=round(raw_usage * fraction),
-                        batch_resource=batch_resource,
-                        start_time=start_time,
-                        end_time=end_time,
-                        labels={
-                            **labels,
-                            'dataset': dataset,
-                            # awkward way to round to 2 decimal places in Python
-                            'fraction': str(round(100 * fraction) / 100),
-                            'dataset_size': str(dataset_size),
-                        },
-                    ),
+                entry = utils.get_hail_entry(
+                    key=key,
+                    topic=dataset,
+                    service_id=SERVICE_ID,
+                    description='Seqr compute (distributed)',
+                    cost=gross_cost * fraction,
+                    currency_conversion_rate=currency_conversion_rate,
+                    usage=round(raw_usage * fraction),
+                    batch_resource=batch_resource,
+                    start_time=start_time,
+                    end_time=end_time,
+                    labels={
+                        **labels,
+                        'dataset': dataset,
+                        # awkward way to round to 2 decimal places in Python
+                        'fraction': str(round(100 * fraction) / 100),
+                        'dataset_size': str(dataset_size),
+                    },
                 )
-
-    entries.extend(
-        utils.get_credits(
-            entries=entries,
-            topic='hail',
-            project=utils.HAIL_PROJECT_FIELD,
-        ),
-    )
-
-    return entries
+                yield entry
+                yield utils.get_credit(
+                    entry=entry,
+                    topic='seqr',
+                    project=utils.SEQR_PROJECT_FIELD,
+                )
 
 
 def get_finalised_entries_for_dataset_batch_and_job(
@@ -255,12 +252,11 @@ def get_finalised_entries_for_dataset_batch_and_job(
     job: dict[str, Any],
     currency_conversion_rate: float,
     ar_guid: str | None,
-):
+) -> Generator[dict[str, Any], None, None]:
     """
     Get the list of entries for a dataset attributed job
 
     """
-    entries = []
 
     job_id = job['job_id']
     job_name = job['attributes'].get('name')
@@ -312,23 +308,19 @@ def get_finalised_entries_for_dataset_batch_and_job(
                 str(job_id),
             ),
         )
-        entries.append(
-            utils.get_hail_entry(
-                key=key,
-                topic=dataset,
-                service_id=SERVICE_ID,
-                description='Seqr compute',
-                cost=cost,
-                currency_conversion_rate=currency_conversion_rate,
-                usage=job['resources'].get(batch_resource, 0),
-                batch_resource=batch_resource,
-                start_time=batch_start_time,
-                end_time=batch_end_time,
-                labels=labels,
-            ),
+        yield utils.get_hail_entry(
+            key=key,
+            topic=dataset,
+            service_id=SERVICE_ID,
+            description='Seqr compute',
+            cost=cost,
+            currency_conversion_rate=currency_conversion_rate,
+            usage=job['resources'].get(batch_resource, 0),
+            batch_resource=batch_resource,
+            start_time=batch_start_time,
+            end_time=batch_end_time,
+            labels=labels,
         )
-
-    return entries
 
 
 def migrate_entries_from_bq(
@@ -444,9 +436,9 @@ def migrate_entries_from_bq(
 
             # For every seqr billing entry migrate it over
             entries.append(obj)
-            entries.extend(
-                utils.get_credits(
-                    entries=[obj],
+            entries.append(
+                utils.get_credit(
+                    entry=obj,
                     topic='seqr',
                     project=utils.SEQR_PROJECT_FIELD,
                 ),
@@ -684,10 +676,10 @@ async def main(
 
         return batches
 
-    def func_get_finalised_entries(batch) -> list[dict[str, Any]]:
+    def func_get_finalised_entries(batch) -> Generator[dict[str, Any], None, None]:
         return get_finalised_entries_for_batch(
-            batch,
-            prop_maps.shared_computation_prop_map,
+            batch=batch,
+            proportion_map=prop_maps.shared_computation_prop_map,
         )
 
     result += await utils.process_entries_from_hail_in_chunks(
@@ -703,7 +695,7 @@ async def main(
     result += migrate_entries_from_bq(
         start,
         end,
-        prop_maps.seqr_hosting_prop_map,
+        prop_map=prop_maps.seqr_hosting_prop_map,
         mode=mode,
         output_path=bq_output_path,
     )

--- a/cpg_infra/billing_aggregator/aggregate/utils.py
+++ b/cpg_infra/billing_aggregator/aggregate/utils.py
@@ -637,8 +637,8 @@ async def process_entries_from_hail_in_chunks(
         max_batch = max(times)
 
         logger.info(
-            f'{lp}Processing {len(batches)} batches for chunk {chunk_counter}/{nchnks} '
-            f'[{min_batch}, {max_batch}]',
+            f'{lp}Processing {len(batch_group)} batches in chunk '
+            f'{chunk_counter}/{nchnks} [{min_batch}, {max_batch}]',
         )
 
         # kick off all the "gets" of the jobs. Note that each "get_jobs" happens
@@ -719,8 +719,8 @@ def upsert_rows_into_bigquery(
             f'adjusting the chunk size to {chunk_size}',
         )
 
-    logger.info(
-        f'Will insert {len(objs)} rows ({total_size_mb:.4f}MB) in {n_chunks} chunks',
+    logger.debug(
+        f'May insert {len(objs)} rows ({total_size_mb:.4f}MB) in {n_chunks} chunks',
     )
 
     inserts = 0
@@ -766,7 +766,7 @@ def upsert_rows_into_bigquery(
         nrows = len(filtered_obj)
 
         if nrows == 0:
-            logger.info(
+            logger.debug(
                 f'Not inserting any rows 0/{len(chunked_objs)} '
                 f'({chunk_idx+1}/{n_chunks} chunk)',
             )
@@ -802,7 +802,8 @@ def upsert_rows_into_bigquery(
         inserts += nrows
         inserted_ids = inserted_ids.union(ids)
 
-    logger.info(f'Inserted {inserts} rows in {n_chunks} chunks')
+    _is_s = '' if inserts == 1 else 's'
+    logger.info(f'Inserted {inserts} rows in {n_chunks} chunk{_is_s}')
     return inserts
 
 


### PR DESCRIPTION
Rather than:

1. getting all batches, then
2. getting all jobs for chunks of batches, then
3. process the entries, inserting early when size of entries is high

Let's change some of this to yield entries back, and process on the fly:

1. Get all batches, then
2. For chunks of batches, trigger off the get_jobs call
3. Grab each job as it's loaded and add to a queue,
4. Process jobs as we get them, from any batch, at any time
5. Insert them all at once, or whenever we reach 10MB (but this is configurable)