### PR TITLE
Remove isort + fix pyproject to sort

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: "3.11"
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,12 +23,6 @@ repos:
     hooks:
       - id: markdownlint
 
-  - repo: https://github.com/pycqa/isort
-    rev: 5.13.2
-    hooks:
-      - id: isort
-        name: isort (python)
-
   - repo: https://github.com/ambv/black
     rev: 23.12.1
     hooks:
@@ -36,12 +30,12 @@ repos:
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.1.11
+    rev: v0.3.2
     hooks:
       - id: ruff
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.8.0
+    rev: v1.9.0
     hooks:
       - id: mypy
         args:

--- a/cpg_infra/driver.py
+++ b/cpg_infra/driver.py
@@ -2,13 +2,13 @@
 """
 CPG Dataset infrastructure
 """
-import graphlib
 import os.path
 import re
 from collections import defaultdict
 from functools import cached_property
 from typing import Any, Callable, Iterable, Iterator, NamedTuple, Type
 
+import graphlib
 import pulumi
 import pulumi_gcp as gcp
 import toml

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,34 +2,19 @@
 line-length = 88
 skip-string-normalization = true
 
-[tool.isort]
-py_version = 311
-profile = "black"
-line_length = 88
-sections = ['FUTURE', 'STDLIB', 'THIRDPARTY', "HAIL", 'CPG', 'FIRSTPARTY', 'LOCALFOLDER']
-known_hail = [
-    "hail",
-    "hailctl",
-]
-known_cpg = [
-    "analysis-runner",
-    "cpg_utils",
-    "cpg_infra",
-    "cpg_workflows",
-    "metamist",
-]
-
 [tool.ruff]
 line-length = 88
 
+[tool.ruff.lint]
 # ignore pydocstyle, flake8-boolean-trap (FBT)
-select = ["A", "B", "C",  "E", "F", "G", "I", "N", "Q", "S", "W", "ANN", "ARG", "BLE", "COM", "DJ", "DTZ", "ERA", "EXE", "ICN", "ISC", "NPY", "PD", "PGH", "PIE", "PL", "PT", "PYI", "RET", "RSE", "RUF", "SIM", "SLF", "TCH", "TID", "UP", "YTT"]
+select = ["A", "B", "C",  "E", "F", "G", "I", "N", "Q", "S", "W", "ANN", "ARG", "BLE", "COM", "DJ", "DTZ", "ERA", "EXE", "ICN", "ISC", "NPY", "PD", "PGH", "PIE", "PL", "PYI", "RET", "RSE", "RUF", "SIM", "SLF", "TCH", "TID", "UP", "YTT"]
 
-fixable = ["A", "B", "C", "D", "E", "F", "G", "I", "N", "Q", "S", "T", "W", "ANN", "ARG", "BLE", "COM", "DJ", "DTZ", "ERA", "EXE", "FBT", "ICN", "ISC", "NPY", "PD", "PGH", "PIE", "PL", "PT", "PYI", "RET", "RSE", "RUF", "SIM", "SLF", "TCH", "TID", "UP", "YTT"]
+fixable = ["A", "B", "C", "D", "E", "F", "G", "I", "N", "Q", "S", "T", "W", "ANN", "ARG", "BLE", "COM", "DJ", "DTZ", "ERA", "EXE", "FBT", "ICN", "ISC", "NPY", "PD", "PGH", "PIE", "PL", "PYI", "RET", "RSE", "RUF", "SIM", "SLF", "TCH", "TID", "UP", "YTT"]
 
 ignore = [
     "ANN101",  # Missing type annotation for self in method
     "ANN201",  # Missing return type annotation for public function
+    "ANN401",  # Dynamically typed expressions (typing.Any) are disallowed in `**kwargs`
     "E501",    # Line length too long
     "E731",    # Do not assign a lambda expression, use a def
     "E741",    # Ambiguous variable name
@@ -42,7 +27,27 @@ ignore = [
     "PT018",   # Assertion should be broken down into multiple parts
     "Q000",    # Single quotes found but double quotes preferred
     "S101",    # Use of assert detected
-    "PT009",   # Use a regular `assert` instead of unittest-style `assertDictEqual`
-    "PT027",   # Use `pytest.raises` instead of unittest-style `assertRaises`
-    "I001",    # Import block is un-sorted or un-formatted (using isort instead)
+]
+
+
+[tool.ruff.lint.isort]
+
+section-order = ["future", "standard-library", "third-party", "hail", "cpg", "first-party", "local-folder"]
+
+[tool.ruff.lint.isort.sections]
+hail = [
+    "hail",
+    "hailtop",
+]
+# Adjust these for each repository, e.g., removing those that should be
+# local rather than CPG. Also fill in extend_skip below if there are any
+# subdirectories that should be ignored.
+cpg = [
+    "analysis_runner",
+    "cpg_infra",
+    "cpg_utils",
+    "cpg_workflows",
+    "gnomad",
+    "hail_scripts",
+    "metamist",
 ]

--- a/reorder_state_file.py
+++ b/reorder_state_file.py
@@ -6,10 +6,10 @@ DANGER:
     This operates on state directly, you should very carefully check the output
     and keep backups before overwriting the state file.
 """
-import graphlib
 import json
 
 import click
+import graphlib
 
 
 def main(state_file: str):

--- a/storage_visualization/main.py
+++ b/storage_visualization/main.py
@@ -4,9 +4,10 @@
 
 import sys
 
+from cloudpathlib import AnyPath
+
 # See requirements.txt for why we're disabling the linter warnings here.
 import hailtop.batch as hb  # pylint: disable=import-error
-from cloudpathlib import AnyPath
 
 from cpg_utils.git import (
     get_git_commit_ref_of_current_repository,


### PR DESCRIPTION
There's some ambiguity with graphlib, as it moved from external to internal in 3.11, but Ruff doesn't support the isort py_version argument. Broadly I think this is actually okay, I'm not fussed with it's placement, as long as it's not inconsistently moved. 