### PR TITLE
Override resource key on secret creation

### DIFF
--- a/cpg_infra/abstraction/azure.py
+++ b/cpg_infra/abstraction/azure.py
@@ -487,9 +487,14 @@ class AzureInfra(CloudInfraBase):
             ),
         )
 
-    def create_secret(self, name: str, project: Optional[str] = None) -> Any:
+    def create_secret(
+        self,
+        name: str,
+        project: Optional[str] = None,
+        resource_key: Optional[str] = None,
+    ) -> Any:
         return az.keyvault.Secret(
-            self.get_pulumi_name('secret-' + name),
+            resource_key or self.get_pulumi_name('secret-' + name),
             secret_name=name,
             properties=az.keyvault.SecretPropertiesArgs(
                 value=None,

--- a/cpg_infra/abstraction/base.py
+++ b/cpg_infra/abstraction/base.py
@@ -275,7 +275,12 @@ class CloudInfraBase(ABC):
     # SECRETS
 
     @abstractmethod
-    def create_secret(self, name: str, project: Optional[str] = None) -> Any:
+    def create_secret(
+        self,
+        name: str,
+        project: Optional[str] = None,
+        resource_key: Optional[str] = None,
+    ) -> Any:
         pass
 
     @abstractmethod
@@ -425,7 +430,12 @@ class DryRunInfra(CloudInfraBase):
     ) -> Any:
         print(f'{resource_key} :: Add {member} to {group}')
 
-    def create_secret(self, name: str, project: Optional[str] = None) -> Any:
+    def create_secret(
+        self,
+        name: str,
+        project: Optional[str] = None,
+        resource_key: Optional[str] = None,
+    ) -> Any:
         print(f'Creating secret: {name}')
         return f'SECRET:{name}'
 

--- a/cpg_infra/abstraction/gcp.py
+++ b/cpg_infra/abstraction/gcp.py
@@ -630,9 +630,14 @@ class GcpInfrastructure(CloudInfraBase):
             opts=pulumi.resource.ResourceOptions(depends_on=[self._svc_cloudidentity]),
         )
 
-    def create_secret(self, name: str, project: Optional[str] = None) -> Any:
+    def create_secret(
+        self,
+        name: str,
+        project: Optional[str] = None,
+        resource_key: Optional[str] = None,
+    ) -> Any:
         return gcp.secretmanager.Secret(
-            self.get_pulumi_name(name),
+            resource_key or self.get_pulumi_name(name),
             secret_id=name,
             replication=gcp.secretmanager.SecretReplicationArgs(
                 user_managed=gcp.secretmanager.SecretReplicationUserManagedArgs(

--- a/cpg_infra/driver.py
+++ b/cpg_infra/driver.py
@@ -2017,8 +2017,11 @@ class CPGDatasetCloudInfrastructure:
                 cromwell_account,
             )
 
+            secret_name = f'{self.dataset_config.dataset}-cromwell-{access_level}-key'
             secret = self.infra.create_secret(
-                f'{self.dataset_config.dataset}-cromwell-{access_level}-key-2',
+                name=secret_name,
+                # this key was created later, so we need to add a suffix
+                resource_key=self.infra.get_pulumi_name(secret_name) + '-2',
             )
 
             # add credentials to the secret
@@ -2052,7 +2055,7 @@ class CPGDatasetCloudInfrastructure:
             #       remove when cpg-utils 5.0.0 is fully released
 
             old_secret = self.infra.create_secret(
-                f'{self.dataset_config.dataset}-cromwell-{access_level}-key',
+                name=secret_name,
                 project=self.config.analysis_runner.gcp.project,  # ANALYSIS_RUNNER_PROJECT,
             )
 


### PR DESCRIPTION
The name of a secret and pulumi key (the unique key that identifies the secret) are explicitly linked, but I want to create two secrets with specific names within the same dataset scope.

So allow the driver to override the pulumi key, and then use this for the cromwell key that I want two of (temporarily).