### PR TITLE
Disable delete protection on BQ materialized views so we can update schema

### DIFF
--- a/cpg_infra/billing_aggregator/driver.py
+++ b/cpg_infra/billing_aggregator/driver.py
@@ -472,6 +472,9 @@ class BillingAggregator(CpgInfrastructurePlugin):
                     enable_refresh=True,
                     refresh_interval_ms=1800000,
                 ),
+                # to be able update schema we need to disable deletion protection
+                # views can be regenerated, there is not need to protect them
+                deletion_protection=False,
                 # Define time-based partitioning on 'purchaseDate' field
                 clusterings=cluster_by,
                 time_partitioning={'type': 'DAY', 'field': 'day'},


### PR DESCRIPTION
Pulumi is failing on materialised views update if they are protected (by default).
Even if manually delete of the view and then run deploy it fails (complaining it does not exist).