### PR TITLE
Fix billing aggregate issues

### DIFF
--- a/cpg_infra/billing_aggregator/aggregate/utils.py
+++ b/cpg_infra/billing_aggregator/aggregate/utils.py
@@ -1117,10 +1117,13 @@ def get_batch_ids_from_request(
             if 'batch_ids' in attributes:
                 request_data = attributes
         elif 'data' in message:
+            # data field can be rubish, esp. when passed from pubsub
+            # if it fails, than just return None
             try:
                 request_data = json.loads(b64decode(message['data']))
-            except Exception as exp:
-                raise exp
+            except ValueError:
+                logger.warning(f'Data is invalid JSON: {message["data"]}')
+                return None
 
     batch_ids = request_data.get('batch_ids')
     if batch_ids:

--- a/cpg_infra/billing_aggregator/driver.py
+++ b/cpg_infra/billing_aggregator/driver.py
@@ -449,7 +449,11 @@ class BillingAggregator(CpgInfrastructurePlugin):
         """
         (project_id, dataset_id, _table_id) = self.extract_dataset_table()
 
-        materialized_views = ['aggregate_daily', 'aggregate_daily_extended']
+        # materialized_views = ['aggregate_daily', 'aggregate_daily_extended']
+        # There is no way to update the view, we need to drop and recreate it
+        # This is the first step to drop existing one from pulimi as well
+        # Second step would be to add the view back in the code
+        materialized_views = ['aggregate_daily']
         for view_name in materialized_views:
             materialized_view_query = get_file_content(
                 f'{PATH_TO_AGGREGATE_SOURCE_CODE}/{view_name}_view.txt',


### PR DESCRIPTION
This PR is fixing 2 issues:
1. When scheduler publishes message to Topic, it is not valid json record. Function get_batch_ids_from_request was an inspired by get_start_and_end_from_request and that re-throws Exception, which is caught one level up.
Function get_batch_ids_from_request is simpler, if not valid json object present then batch_ids is not present, simply return None.

2. Updating BQ materialised views via Pulumi is a bit catch 22, it seems the only possible solution is to remove the view and then created back. This PR is removing the view first.
There will be following PR which add it back in.