### PR TITLE
Seqr - memory optimisation - only add missing records to the list of entries to be updated.

### DIFF
--- a/cpg_infra/billing_aggregator/aggregate/seqr.py
+++ b/cpg_infra/billing_aggregator/aggregate/seqr.py
@@ -443,7 +443,8 @@ def migrate_entries_from_bq(
             obj['id'] = nid
 
             # For every seqr billing entry migrate it over
-            entries.append(obj) if obj['id'] not in existing_ids else None
+            if obj['id'] not in existing_ids:
+                entries.append(obj)
 
             # For every seqr billing entry, add credit entry
             obj_credit = utils.get_credit(
@@ -451,7 +452,8 @@ def migrate_entries_from_bq(
                 topic='seqr',
                 project=utils.SEQR_PROJECT_FIELD,
             )
-            entries.append(obj_credit) if obj_credit['id'] not in existing_ids else None
+            if obj_credit['id'] not in existing_ids:
+                entries.append(obj_credit)
 
             for dataset, (ratio, dataset_size) in _obj_param_map.items():
                 new_entry = copy.deepcopy(obj)

--- a/cpg_infra/billing_aggregator/aggregate/seqr.py
+++ b/cpg_infra/billing_aggregator/aggregate/seqr.py
@@ -395,7 +395,7 @@ def migrate_entries_from_bq(
 
             json_objs_iter = generator()
 
-    def _append_if_not_present(entries, obj):
+    def _append_if_not_present(entries: list[dict], obj: dict) -> None:
         """
         Append records if not already in the table
         """
@@ -404,7 +404,7 @@ def migrate_entries_from_bq(
             entries.append(obj)
 
     for json_objs in json_objs_iter:
-        entries = []
+        entries: list[dict] = []
         seqr_wide_param_map, current_date = None, None
         for obj in json_objs:
             labels = utils.reformat_bigqquery_labels(obj['labels'])


### PR DESCRIPTION
Background, when trying to process batch https://batch.hail.populationgenomics.org.au/batches/430882
, which took over a week to process, the function runs out of memory because it is trying to prepare the list of all gcp records for that time. Even most of them would be already upserted as seqr scheduled aggregation runs every 4 hours.

This PR checks if records exist and only add it to a list if not present.
This should minimise the list passed around and therefore minimising function RAM requirements.