### PR TITLE
Trying to fix BQ materialize view schema update.

### DIFF
--- a/cpg_infra/billing_aggregator/aggregate/aggregate_daily_extended_view.txt
+++ b/cpg_infra/billing_aggregator/aggregate/aggregate_daily_extended_view.txt
@@ -24,7 +24,7 @@ MIN(usage_start_time) as usage_start_time,
 MAX(usage_end_time) as usage_end_time,
 SUM(cost) as cost
 FROM `%AGGREGATE_TABLE%`
-WHERE NOT REGEXP_CONTAINS(LOWER(service.description), r'credit')
+WHERE NOT REGEXP_CONTAINS(LOWER(service.description), r'credit|distributed')
 GROUP BY day, topic, cost_category, sku, invoice_month, ar_guid, dataset, batch_id, job_id, sequencing_type, stage, sequencing_group,
 compute_category,
 cromwell_sub_workflow_name,

--- a/cpg_infra/billing_aggregator/driver.py
+++ b/cpg_infra/billing_aggregator/driver.py
@@ -449,11 +449,11 @@ class BillingAggregator(CpgInfrastructurePlugin):
         """
         (project_id, dataset_id, _table_id) = self.extract_dataset_table()
 
-        # materialized_views = ['aggregate_daily', 'aggregate_daily_extended']
+        materialized_views = ['aggregate_daily', 'aggregate_daily_extended']
         # There is no way to update the view, we need to drop and recreate it
         # This is the first step to drop existing one from pulimi as well
         # Second step would be to add the view back in the code
-        materialized_views = ['aggregate_daily']
+        # materialized_views = ['aggregate_daily']
         for view_name in materialized_views:
             materialized_view_query = get_file_content(
                 f'{PATH_TO_AGGREGATE_SOURCE_CODE}/{view_name}_view.txt',


### PR DESCRIPTION
Pulumi / GCP does not support schema update for BQ materialised views. The only way is to delete and recreate the view.
Problem start when MV is created without 'deletion_protection=False'. Basically Pulumi can not delete the view so update would cause en error. Removing the view does not work either. A bit of catch 22.
This PR is trying to roll back original schema with 'deletion_protection=False'.