### PR TITLE
Limit hail batches to max 50K jobs, aggregate any larger ones.

### DIFF
--- a/cpg_infra/billing_aggregator/aggregate/utils.py
+++ b/cpg_infra/billing_aggregator/aggregate/utils.py
@@ -94,10 +94,10 @@ ANALYSIS_RUNNER_PROJECT_ID = 'analysis-runner'
 
 # Maximum job count before all jobs gets summarised into one row
 # This is to prevent the bigquery inserts taking too long
-# Seqr jobs over 9K are going to be aggregated into one job.
-SEQR_MAX_JOBS_PER_BATCH = 9000
-# For hail jobs this limit is 50K
-HAIL_MAX_JOBS_PER_BATCH = 50000
+# Seqr / hail query jobs over 9K are going to be aggregated into one job.
+HAIL_QUERY_JOB_PER_BATCH_LIMIT = 9000
+# For hail non query jobs this limit is 50K
+HAIL_NON_QUERY_JOB_PER_BATCH_LIMIT = 50000
 
 # runs every 4 hours
 DEFAULT_RANGE_INTERVAL = timedelta(hours=int(os.getenv('DEFAULT_INTERVAL_HOURS', '4')))
@@ -672,9 +672,9 @@ async def process_entries_from_hail_in_chunks(
             return
 
         batch_name = batch.get('attributes', {}).get('name')
-        # check if hail batch query and too many jobs
-        if (batch_name is None and jobs_cnt > SEQR_MAX_JOBS_PER_BATCH) or (
-            batch_name is not None and jobs_cnt > HAIL_MAX_JOBS_PER_BATCH
+        # check if hail batch has too many jobs
+        if (batch_name is None and jobs_cnt > HAIL_QUERY_JOB_PER_BATCH_LIMIT) or (
+            batch_name is not None and jobs_cnt > HAIL_NON_QUERY_JOB_PER_BATCH_LIMIT
         ):
             # This is batch with too many jobs, we need to aggregate them
             # batch contains all the costs as cost_breakdown

--- a/cpg_infra/billing_aggregator/aggregate/utils.py
+++ b/cpg_infra/billing_aggregator/aggregate/utils.py
@@ -94,8 +94,10 @@ ANALYSIS_RUNNER_PROJECT_ID = 'analysis-runner'
 
 # Maximum job count before all jobs gets summarised into one row
 # This is to prevent the bigquery inserts taking too long
-# Jobs over 9K are going to be aggregated into one job.
-DEFAULT_MAX_JOBS_PER_BATCH = 9000
+# Seqr jobs over 9K are going to be aggregated into one job.
+SEQR_MAX_JOBS_PER_BATCH = 9000
+# For hail jobs this limit is 50K
+HAIL_MAX_JOBS_PER_BATCH = 50000
 
 # runs every 4 hours
 DEFAULT_RANGE_INTERVAL = timedelta(hours=int(os.getenv('DEFAULT_INTERVAL_HOURS', '4')))
@@ -671,8 +673,10 @@ async def process_entries_from_hail_in_chunks(
 
         batch_name = batch.get('attributes', {}).get('name')
         # check if hail batch query and too many jobs
-        if batch_name is None and jobs_cnt > DEFAULT_MAX_JOBS_PER_BATCH:
-            # This is most likely Hail Batch Query job, aggregate it as one job
+        if (batch_name is None and jobs_cnt > SEQR_MAX_JOBS_PER_BATCH) or (
+            batch_name is not None and jobs_cnt > HAIL_MAX_JOBS_PER_BATCH
+        ):
+            # This is batch with too many jobs, we need to aggregate them
             # batch contains all the costs as cost_breakdown
             # we just need to reformat it to match the JobType
             cost_breakdown = batch.get('cost_breakdown', [])


### PR DESCRIPTION
When very large batches are being loaded (e.g. https://batch.hail.populationgenomics.org.au/batches/444166), cloud function was running out of memory. This particular batch had over 370K jobs, which generated over 4 million records for the billing BQ table.
We had decided to aggregate hail batches if they reach 50K jobs.