### PR TITLE
Use update cpg-utils path-names

### DIFF
--- a/storage_visualization/disk_usage.py
+++ b/storage_visualization/disk_usage.py
@@ -12,7 +12,7 @@ import google.api_core.exceptions
 from cloudpathlib import AnyPath
 from google.cloud import storage
 
-from cpg_utils.hail_batch import get_config
+from cpg_utils.config import get_access_level
 
 # It's important not to list the `archive` bucket here, as Class B operations are very
 # expensive for that storage class.
@@ -69,7 +69,7 @@ def main():
 
     storage_client = storage.Client()
     dataset = sys.argv[1]
-    access_level = get_config()['workflow']['access_level']
+    access_level = get_access_level()
 
     aggregate_stats = defaultdict(lambda: defaultdict(int))
     for bucket_suffix in BUCKET_SUFFIXES:

--- a/storage_visualization/main.py
+++ b/storage_visualization/main.py
@@ -9,13 +9,17 @@ from cloudpathlib import AnyPath
 # See requirements.txt for why we're disabling the linter warnings here.
 import hailtop.batch as hb  # pylint: disable=import-error
 
+from cpg_utils.config import output_path
 from cpg_utils.git import (
     get_git_commit_ref_of_current_repository,
     get_organisation_name_from_current_directory,
     get_repo_name_from_current_directory,
+)
+from cpg_utils.hail_batch import (
+    copy_common_env,
+    get_batch,
     prepare_git_job,
 )
-from cpg_utils.hail_batch import copy_common_env, get_batch, output_path
 from cpg_utils.slack import upload_file
 
 DOCKER_IMAGE = (


### PR DESCRIPTION
`prepare_git_job` was moved without a deprecated stub, so fix that and other imports in this repo.