### PR TITLE
Make storage-viz more durable

### DIFF
--- a/storage_visualization/disk_usage.py
+++ b/storage_visualization/disk_usage.py
@@ -11,6 +11,7 @@ from collections import defaultdict
 import google.api_core.exceptions
 from cloudpathlib import AnyPath
 from google.cloud import storage
+from humanize import naturalsize
 
 from cpg_utils.config import get_access_level
 
@@ -105,7 +106,8 @@ def count_stats_for_bucket(
         for blob in blobs:
             count += 1
             if count % 10**6 == 0:
-                logging.info(f'{count // 10**6} M blobs...')
+                s = naturalsize(sys.getsizeof(aggregate_stats_container))
+                logging.info(f'{count // 10**6} M blobs... aggregate dict is using {s}')
             folder = f'/{aggregate_level(blob.name)}'
             while True:
                 path = f'gs://{bucket_name}{folder}'

--- a/storage_visualization/main.py
+++ b/storage_visualization/main.py
@@ -4,8 +4,6 @@
 
 import sys
 
-from cloudpathlib import AnyPath
-
 # See requirements.txt for why we're disabling the linter warnings here.
 import hailtop.batch as hb  # pylint: disable=import-error
 
@@ -20,14 +18,13 @@ from cpg_utils.hail_batch import (
     get_batch,
     prepare_git_job,
 )
-from cpg_utils.slack import upload_file
 
 DOCKER_IMAGE = (
     'australia-southeast1-docker.pkg.dev/cpg-common/images/storage-visualization:latest'
 )
 
 
-def prepare_job(job: hb.batch.job.Job, clone_repo: bool):
+def prepare_job(job: hb.batch.job.BashJob, clone_repo: bool):
     """Sets up the given job to run scripts in the same repository."""
     job.image(DOCKER_IMAGE)
     copy_common_env(job)
@@ -38,20 +35,6 @@ def prepare_job(job: hb.batch.job.Job, clone_repo: bool):
             repo_name=get_repo_name_from_current_directory(),
             commit=get_git_commit_ref_of_current_repository(),
         )
-
-
-def post_to_slack():
-    """Posts the URL of the generated treemap together with a preview image to Slack."""
-    with AnyPath(output_path('treemap.png', dataset='common', category='web')).open(
-        'rb',
-    ) as f:
-        content = f.read()
-
-    upload_file(
-        content=content,
-        comment='Storage visualization: '
-        + output_path('treemap.html', dataset='common', category='web_url'),
-    )
 
 
 def main():
@@ -72,6 +55,7 @@ def main():
         # getting preempted.
         job._preemptible = False  # pylint: disable=protected-access
         job.cpu(0.5)
+        job.memory('highmem')
 
         path = output_path(f'{dataset}.json.gz', dataset='common', category='analysis')
         job.command(f'storage_visualization/disk_usage.py {dataset} {path}')
@@ -81,19 +65,21 @@ def main():
     # Process the combined output of all jobs to generate a web report.
     treemap_job = batch.new_job(name='treemap')
     prepare_job(treemap_job, clone_repo=True)
+    # just don't show the specific report if it fails
+    treemap_job.always_run(True)
     for job in job_output_paths:
         treemap_job.depends_on(job)
 
-    web_path = output_path('treemap', dataset='common', category='web')
-    treemap_job.command(
-        f'storage_visualization/treemap.py --output-prefix {web_path} --group-by-dataset {" ".join(f"--input {path}" for path in job_output_paths.values())}',
+    input_commands = " ".join(
+        f"\\\n    --input {path}" for path in job_output_paths.values()
     )
-
-    # Send a Slack message when the HTML page has been generated.
-    slack_job = batch.new_python_job(name='slack')
-    prepare_job(slack_job, clone_repo=False)
-    slack_job.depends_on(treemap_job)
-    slack_job.call(post_to_slack)
+    treemap_job.command(
+        f"""
+storage_visualization/treemap.py \\
+    --group-by-dataset \\
+    --post-slack-message {input_commands}
+    """,
+    )
 
     batch.run(wait=False)
 

--- a/storage_visualization/treemap.py
+++ b/storage_visualization/treemap.py
@@ -6,6 +6,7 @@ import argparse
 import gzip
 import json
 import logging
+import os
 import re
 from collections import defaultdict
 from typing import Any
@@ -15,8 +16,14 @@ import pandas as pd
 import plotly.express as px
 from cloudpathlib import AnyPath
 
+from cpg_utils.config import output_path
+from cpg_utils.slack import upload_file
+
 ROOT_NODE = '<root>'
 DATASET_REGEX = re.compile(r'gs:\/\/cpg-([A-z0-9-]+)-(main|test)')
+DOCKER_IMAGE = (
+    'australia-southeast1-docker.pkg.dev/cpg-common/images/storage-visualization:latest'
+)
 
 
 def get_parser():
@@ -31,11 +38,6 @@ def get_parser():
         action='append',
     )
     parser.add_argument(
-        '--output-prefix',
-        help='The path prefix for HTML report and image outputs; supports cloud paths',
-        required=True,
-    )
-    parser.add_argument(
         '--max-depth',
         help='Maximum folder depth to display',
         default=3,
@@ -44,6 +46,11 @@ def get_parser():
     parser.add_argument(
         '--group-by-dataset',
         help='Group buckets by the dataset',
+        action='store_true',
+    )
+    parser.add_argument(
+        '--post-slack-message',
+        help='Post the generated treemap to Slack',
         action='store_true',
     )
 
@@ -78,53 +85,35 @@ def form_row(name: str, parent: str, values: dict[str, Any]) -> tuple:
     )
 
 
-def main() -> None:
-    """Main entrypoint."""
+def post_to_slack(
+    treemap_png_path: str,
+    treemap_html_web_url: str,
+    missing_datasets: list[str],
+):
+    """Posts the URL of the generated treemap together with a preview image to Slack."""
+    with AnyPath(treemap_png_path).open('rb') as f:
+        content = f.read()
 
-    logging.getLogger().setLevel(logging.INFO)
-    args = get_parser().parse_args()
+    comment = 'Storage visualization: ' + treemap_html_web_url
+    if missing_datasets:
+        comment += '\n\\Missing datasets:\n' + '\n'.join(
+            str(e) for e in missing_datasets
+        )
 
-    rows: list[tuple] = []
+        if batch_id := os.getenv('HAIL_BATCH_ID'):
+            comment += f'\n\nSee https://batch.hail.populationgenomicd.org.au/batches/{batch_id} for more details.'
 
-    root_values: dict[str, int] = defaultdict(int)
-    group_by_dataset = args.group_by_dataset
-    datasets: dict[str, dict[str, int]] = defaultdict(lambda: defaultdict(int))
-    for input_path in args.input:
-        logging.info(f'Processing {input_path}')
-        with AnyPath(input_path).open('rb') as f, gzip.open(f, 'rt') as gfz:
-            for name, vals in json.load(gfz).items():
-                depth = name.count('/') - 1  # Don't account for gs:// scheme.
-                if depth > args.max_depth:
-                    continue
-                size = vals['size']
-                if not size:
-                    continue
-                # Strip one folder for the parent name. Map `gs://` to the
-                # predefined treemap root node label.
-                slash_index = name.rfind('/')
-                if slash_index > len('gs://'):
-                    parent = name[:slash_index]
-                else:
-                    for k, v in vals.items():
-                        root_values[k] += v
-                    match = DATASET_REGEX.search(name)
-                    # fall back to ROOT_NODE if can't determine parent
-                    dataset = match.groups()[0] if match else None
-                    if dataset and group_by_dataset:
-                        parent = dataset
-                        for k, v in vals.items():
-                            datasets[dataset][k] += v
-                    else:
-                        parent = ROOT_NODE
+    upload_file(
+        content=content,
+        comment='Storage visualization: ' + treemap_html_web_url,
+    )
 
-                rows.append(form_row(name, parent, vals))
 
-    for dataset, values in datasets.items():
-        rows.append(form_row(dataset, ROOT_NODE, values))
-
-    # Finally, add the overall root.
-    rows.append(form_row(ROOT_NODE, '', root_values))
-
+def generate_and_write_treemap(
+    rows: list[tuple],
+    output_html: str,
+    output_png: str,
+):
     dataframe = pd.DataFrame(
         # The column name list needs to match the `append_row` implementation.
         rows,
@@ -168,11 +157,128 @@ def main() -> None:
     )
     fig.update_traces(root_color='lightgrey')
 
-    logging.info(f'Writing results to {args.output_prefix}')
-    with AnyPath(f'{args.output_prefix}.html').open('wt') as f:
+    with AnyPath(output_html).open('wt') as f:
         fig.write_html(f)
-    with AnyPath(f'{args.output_prefix}.png').open('wb') as f:
+    with AnyPath(output_png).open('wb') as f:
         fig.write_image(f, width=1920, height=1080)
+
+
+def prepare_rows_from_input_paths(  # noqa: C901
+    input_paths: list[str],
+    max_depth: int,
+    group_by_dataset: bool,
+) -> tuple[list[tuple], list[str]]:
+    """Prepare rows for a dataframe from the given input paths.
+
+    Args:
+        input_paths (list[str]): json.gz files produced from disk_usage.py
+        max_depth (int): Maximum folder depth to display
+        group_by_dataset (bool): Group bucket storage stats by their dataset
+
+    Returns:
+        tuple[list[tuple], list[str]]: (rows, errors)
+    """
+    rows: list[tuple] = []
+
+    root_values: dict[str, int] = defaultdict(int)
+    datasets: dict[str, dict[str, int]] = defaultdict(lambda: defaultdict(int))
+    missing_datasets: list[str] = []
+    for input_path in input_paths:
+        logging.info(f'Processing {input_path}')
+        p = AnyPath(input_path)
+
+        if not p.exists():
+            dataset = os.path.basename(input_path).removesuffix('.json.gz')
+            missing_datasets.append(dataset)
+            continue
+
+        with AnyPath(input_path).open('rb') as f, gzip.open(f, 'rt') as gfz:
+            for name, vals in json.load(gfz).items():
+                depth = name.count('/') - 1  # Don't account for gs:// scheme.
+                if depth > max_depth:
+                    continue
+                size = vals['size']
+                if not size:
+                    continue
+                # Strip one folder for the parent name. Map `gs://` to the
+                # predefined treemap root node label.
+                slash_index = name.rfind('/')
+                if slash_index > len('gs://'):
+                    parent = name[:slash_index]
+                else:
+                    for k, v in vals.items():
+                        root_values[k] += v
+                    match = DATASET_REGEX.search(name)
+                    # fall back to ROOT_NODE if can't determine parent
+                    dataset = match.groups()[0] if match else None
+                    if dataset and group_by_dataset:
+                        parent = dataset
+                        for k, v in vals.items():
+                            datasets[dataset][k] += v
+                    else:
+                        parent = ROOT_NODE
+
+                rows.append(form_row(name, parent, vals))
+
+    for dataset, values in datasets.items():
+        rows.append(form_row(dataset, ROOT_NODE, values))
+
+    # Finally, add the overall root.
+    rows.append(form_row(ROOT_NODE, '', root_values))
+
+    return rows, missing_datasets
+
+
+def main() -> None:
+    """Main entrypoint."""
+
+    logging.getLogger().setLevel(logging.INFO)
+    args = get_parser().parse_args()
+
+    should_post_to_slack = args.post_slack_message
+
+    try:
+        rows, missing_datasets = prepare_rows_from_input_paths(
+            args.input,
+            args.max_depth,
+            args.group_by_dataset,
+        )
+
+        logging.info('Writing results')
+        output_html_path = output_path('treemap.html', category='web', dataset='common')
+
+        web_html_path = output_path(
+            'treemap.html',
+            category='web_url',
+            dataset='common',
+        )
+        generate_and_write_treemap(
+            rows=rows,
+            output_html=output_html_path,
+            # write locally to use in slack message
+            output_png='treemap.png',
+        )
+
+        if should_post_to_slack:
+            post_to_slack(
+                treemap_png_path='treemap.png',
+                treemap_html_web_url=web_html_path,
+                missing_datasets=missing_datasets,
+            )
+    except Exception as e:  # noqa: BLE001
+        comment = f'Failed to generate storage viz treemap: {e}'
+        if batch_id := os.getenv('HAIL_BATCH_ID'):
+            url = f"https://batch.hail.populationgenomicd.org.au/batches/{batch_id}"
+            if job_id := os.getenv('HAIL_JOB_ID'):
+                url += f"/jobs/{job_id}"
+
+            comment += f"\n\nSee {url} for more details."
+        if should_post_to_slack:
+            upload_file(
+                content=b'Failed to generate storage viz treemap',
+                comment=comment,
+            )
+        raise Exception(comment) from e
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
An intermediate storage viz (https://batch.hail.populationgenomics.org.au/batches/445677) failed for an [out-of-memory issues](https://batch.hail.populationgenomics.org.au/batches/445677/jobs/5).

There are two options, but the easiest is to bump the memory, and fail the dataset. Some later options is partition by bucket instead of dataset, but let's do it later if we need.

Also make the last aggregate bash always run, and just post an error if datasets are missing.

Also, noting the actual path construction was pretty disconnected, an output_prefix was supplied, but then the output_path function was used later to construct the web URL prefix. I tested the aggregation works locally. 