### PR TITLE
Replacing Billing Aggregate Pub/Sub with Cloud Scheduler

### DIFF
--- a/cpg_infra/billing_aggregator/aggregate/requirements.txt
+++ b/cpg_infra/billing_aggregator/aggregate/requirements.txt
@@ -5,8 +5,9 @@ metamist
 pyyaml
 python-rapidjson
 google-api-python-client==2.79.0
-google-cloud-bigquery==3.6.0
+google-cloud-bigquery==3.11.4
 google-cloud-secret-manager==2.15.1
 google-cloud-logging==3.5.0
-pandas==1.5.3
-pandas-gbq==0.19.1
+numpy==1.23.2
+pandas==2.0.1
+pandas-gbq==0.23.1

--- a/cpg_infra/billing_aggregator/driver.py
+++ b/cpg_infra/billing_aggregator/driver.py
@@ -62,7 +62,6 @@ class BillingAggregator(CpgInfrastructurePlugin):
             return
 
         self.setup_aggregator_functions()
-        self.setup_update_budget()
         # setup BQ objects
         _ = self.aggregate_table
         self.setup_materialized_views()
@@ -172,27 +171,6 @@ class BillingAggregator(CpgInfrastructurePlugin):
             opts=pulumi.ResourceOptions(replace_on_changes=['*']),
         )
 
-        # Create one pubsub to be triggered by the cloud scheduler
-        pubsub = gcp.pubsub.Topic(
-            'billing-aggregator-topic',
-            project=self.config.billing.gcp.project_id,
-            opts=pulumi.ResourceOptions(depends_on=[self.pubsub_service]),
-        )
-
-        # Create a cron job to run the aggregator function on some interval
-        _ = gcp.cloudscheduler.Job(
-            'billing-aggregator-scheduler-job',
-            pubsub_target=gcp.cloudscheduler.JobPubsubTargetArgs(
-                topic_name=pubsub.id,
-                data=b64encode_str('Run the functions'),
-            ),
-            schedule=f'0 */{self.config.billing.aggregator.interval_hours} * * *',
-            project=self.config.billing.gcp.project_id,
-            region=self.config.gcp.region,
-            time_zone='Australia/Sydney',
-            opts=pulumi.ResourceOptions(depends_on=[self.scheduler_service]),
-        )
-
         for function in self.config.billing.aggregator.functions:
             # Balance CPU by this table:
             # https://cloud.google.com/functions/docs/configuring/memory
@@ -206,10 +184,9 @@ class BillingAggregator(CpgInfrastructurePlugin):
             # Create the function, the trigger and subscription.
             _ = self.create_cloud_function(
                 resource_name=f'billing-aggregator-{function}-billing-function',
-                name=function,
+                name=f'billing-aggregator-{function}-billing-function',
                 source_file=f'{function}.py',
                 service_account=self.config.billing.coordinator_machine_account,
-                pubsub_topic=pubsub,
                 source_archive_object=source_archive_object,
                 notification_channel=self.slack_channel,
                 memory=memory,
@@ -226,6 +203,20 @@ class BillingAggregator(CpgInfrastructurePlugin):
                 },
             )
 
+            # create cron job to run each function as a separate job
+            _ = gcp.cloudscheduler.Job(
+                f'billing-aggregator-scheduler-job-{function}',
+                http_target=gcp.cloudscheduler.JobHttpTargetArgs(
+                    uri=f'https://{self.config.gcp.region}-{self.config.billing.gcp.project_id}.cloudfunctions.net/billing-aggregator-{function}-billing-function',
+                    http_method='POST',
+                ),
+                schedule=f'0 */{self.config.billing.aggregator.interval_hours} * * *',
+                project=self.config.billing.gcp.project_id,
+                region=self.config.gcp.region,
+                time_zone='Australia/Sydney',
+                opts=pulumi.ResourceOptions(depends_on=[self.scheduler_service]),
+            )
+
     # monthly billing aggregator
 
     def create_cloud_function(
@@ -233,7 +224,6 @@ class BillingAggregator(CpgInfrastructurePlugin):
         resource_name: str,
         name: str,
         service_account: str,
-        pubsub_topic: gcp.pubsub.Topic,
         source_archive_object: gcp.storage.BucketObject,
         notification_channel: gcp.monitoring.NotificationChannel,
         env: dict,
@@ -243,17 +233,14 @@ class BillingAggregator(CpgInfrastructurePlugin):
         cpu: int | None = None,
     ):
         """
-        Create a single Cloud Function. Include the pubsub trigger and event alerts
+        Create a single Cloud Function. Include the http trigger and event alerts
         """
 
         assert self.config.billing
 
-        # Trigger for the function, subscribe to the pubusub topic
         trigger = gcp.cloudfunctionsv2.FunctionEventTriggerArgs(
-            event_type='google.cloud.pubsub.topic.v1.messagePublished',
-            trigger_region='australia-southeast1',
-            pubsub_topic=pubsub_topic.id,
-            retry_policy='RETRY_POLICY_DO_NOT_RETRY',
+            event_type="google.cloud.functions.v1.Function.TriggerType.HTTP_REQUEST",
+            trigger=None,
         )
 
         # Create the Cloud Function
@@ -337,62 +324,6 @@ class BillingAggregator(CpgInfrastructurePlugin):
         )
 
         return fxn, trigger, alert_policy
-
-    def setup_update_budget(self):
-        assert self.config.billing
-        assert self.config.gcp
-
-        # The Cloud Function source code itself needs to be zipped up into an
-        # archive, which we create using the pulumi.AssetArchive primitive.
-        archive = archive_folder(PATH_TO_UPDATE_BUDGET_SOURCE_CODE)
-        # Create the single Cloud Storage object, which contains the source code
-        source_archive_object = gcp.storage.BucketObject(
-            'billing-update-budget-source-code',
-            # updating the source archive object does not trigger the cloud function
-            # to actually updating the source because it's based on the name,
-            # allow Pulumi to create a new name each time it gets updated
-            bucket=self.source_bucket.name,
-            source=archive,
-            opts=pulumi.ResourceOptions(replace_on_changes=['*']),
-        )
-
-        pubsub = gcp.pubsub.Topic(
-            'billing-update-budget-topic',
-            project=self.config.billing.gcp.project_id,
-            opts=pulumi.ResourceOptions(depends_on=[self.pubsub_service]),
-        )
-
-        # Create a cron job to run the budget update function on some interval
-        _ = gcp.cloudscheduler.Job(
-            'billing-update-budget-scheduler-job',
-            pubsub_target=gcp.cloudscheduler.JobPubsubTargetArgs(
-                topic_name=pubsub.id,
-                data=b64encode_str('Run the functions'),
-            ),
-            # Run daily at 3am
-            schedule='0 3 * * *',
-            project=self.config.billing.gcp.project_id,
-            region=self.config.gcp.region,
-            time_zone='Australia/Sydney',
-            opts=pulumi.ResourceOptions(depends_on=[self.scheduler_service]),
-        )
-
-        _ = self.create_cloud_function(
-            resource_name='billing-update-budget-function',
-            name='update-budget',
-            service_account=self.config.billing.coordinator_machine_account,
-            pubsub_topic=pubsub,
-            source_archive_object=source_archive_object,
-            notification_channel=self.slack_channel,
-            project=self.config.billing.gcp.project_id,
-            env={
-                'BILLING_ACCOUNT_ID': self.config.billing.gcp.account_id,
-                # TODO create new config property for this
-                'BQ_BILLING_MONTHLY_BUDGET_TABLE': (
-                    f'{self.config.billing.gcp.project_id}.billing.budget_by_project_monthly'
-                ),
-            },
-        )
 
     def extract_dataset_table(self):
         expected_table_name_parts = 3

--- a/cpg_infra/config/config.py
+++ b/cpg_infra/config/config.py
@@ -197,7 +197,7 @@ class CPGInfrastructureConfig(DeserializableDataclass):
             functions: list[str]
             billing_sheet_id: str | None = None
             monthly_summary_table: str | None = None
-            interval_hours: int = 2
+            interval_hours: int = 4
 
         gcp: GCP
         coordinator_machine_account: str | None = None

--- a/cpg_infra/config/config.py
+++ b/cpg_infra/config/config.py
@@ -197,7 +197,7 @@ class CPGInfrastructureConfig(DeserializableDataclass):
             functions: list[str]
             billing_sheet_id: str | None = None
             monthly_summary_table: str | None = None
-            interval_hours: int = 4
+            interval_hours: int = 2
 
         gcp: GCP
         coordinator_machine_account: str | None = None


### PR DESCRIPTION
This PR includes:
- replace Pub/Sub approach for loading billing data with Cloud Scheduler, which allows to run for up to 1 hours (Pub/Sub has 9 mins limit)
- remove the update billing budget function as this is not used and will be implemented as part of cpg-infra-private GitHub action.
