### PR TITLE
Update metamist project member provider to handle new permissions structure

### DIFF
--- a/cpg_infra/abstraction/metamist.py
+++ b/cpg_infra/abstraction/metamist.py
@@ -3,6 +3,7 @@
 Pulumi provider for interacting with metamist
 """
 import functools
+from collections import defaultdict
 from typing import Any
 
 import pulumi
@@ -104,20 +105,30 @@ class MetamistProjectMembersProvider(pulumi.dynamic.ResourceProvider):
         project_name = props['project_name']
         read_members = props['read_members']
         write_members = props['write_members']
+        contribute_members = props['contribute_members']
+
+        member_roles = [
+            (read_members, 'reader'),
+            (write_members, 'writer'),
+            (contribute_members, 'contributor'),
+        ]
+
+        project_member_dict: defaultdict[str, set[str]] = defaultdict(set)
+
+        for member_list, role in member_roles:
+            for member in member_list:
+                project_member_dict[member].add(role)
+
+        project_member_update = [
+            {'member': member, 'roles': list(roles)}
+            for member, roles in project_member_dict.items()
+        ]
 
         papi = ProjectApi()
         papi.update_project_members(
             project=project_name,
-            request_body=read_members,
-            readonly=True,
+            project_member_update=project_member_update,
         )
-
-        papi.update_project_members(
-            project=project_name,
-            request_body=write_members,
-            readonly=False,
-        )
-
         return pulumi.dynamic.CreateResult(
             id_=f'metamist-project-members::{project_name}',
             outs={**props},
@@ -153,11 +164,13 @@ class MetamistProjectMembers(pulumi.dynamic.Resource):
         metamist_project_name: str | pulumi.Output[str],
         read_members: list[str] | pulumi.Output[list[str]],
         write_members: list[str] | pulumi.Output[list[str]],
+        contribute_members: list[str] | pulumi.Output[list[str]],
         opts: pulumi.ResourceOptions | None = None,
     ) -> None:
         args = {
             'project_name': metamist_project_name,
             'read_members': read_members,
             'write_members': write_members,
+            'contribute_members': contribute_members,
         }
         super().__init__(MetamistProjectMembersProvider(), name, args, opts)

--- a/cpg_infra/driver.py
+++ b/cpg_infra/driver.py
@@ -51,13 +51,17 @@ class SampleMetadataAccessorMembership(NamedTuple):
 
 SM_TEST_READ = 'test-read'
 SM_TEST_WRITE = 'test-write'
+SM_TEST_CONTRIBUTE = 'test-contribute'
 SM_MAIN_READ = 'main-read'
 SM_MAIN_WRITE = 'main-write'
+SM_MAIN_CONTRIBUTE = 'main-contribute'
 METAMIST_PERMISSIONS = [
     SM_TEST_READ,
     SM_TEST_WRITE,
+    SM_TEST_CONTRIBUTE,
     SM_MAIN_READ,
     SM_MAIN_WRITE,
+    SM_MAIN_CONTRIBUTE,
 ]
 
 
@@ -575,6 +579,7 @@ class CPGInfrastructure:
                 f'{dataset}-metamist-members',
                 metamist_project_name=infra.metamist_project.project_name,
                 read_members=prepare_group_members(infra, SM_MAIN_READ),
+                contribute_members=prepare_group_members(infra, SM_MAIN_CONTRIBUTE),
                 write_members=prepare_group_members(infra, SM_MAIN_WRITE),
             )
 
@@ -583,6 +588,7 @@ class CPGInfrastructure:
                     f'{dataset}-metamist-test-members',
                     metamist_project_name=infra.metamist_test_project.project_name,
                     read_members=prepare_group_members(infra, SM_TEST_READ),
+                    contribute_members=prepare_group_members(infra, SM_TEST_CONTRIBUTE),
                     write_members=prepare_group_members(infra, SM_TEST_WRITE),
                 )
 
@@ -2288,7 +2294,13 @@ class CPGDatasetCloudInfrastructure:
             SampleMetadataAccessorMembership(
                 name='human',
                 member=self.analysis_group,
-                permissions=(SM_MAIN_READ, SM_TEST_READ, SM_TEST_WRITE),
+                permissions=(
+                    SM_MAIN_READ,
+                    SM_MAIN_CONTRIBUTE,
+                    SM_TEST_READ,
+                    SM_TEST_WRITE,
+                    SM_TEST_CONTRIBUTE,
+                ),
             ),
             SampleMetadataAccessorMembership(
                 name='data-manager-group',


### PR DESCRIPTION
Relates to populationgenomics/metamist#829

- Update custom metamist project member provider to send through a list of members and roles for a project, rather than adding members to specific groups.
- Add contributor role for anyone tagged as an analysis member
