### PR TITLE
Adjust Billing BQ filters to use partitions

### DIFF
--- a/cpg_infra/billing_aggregator/aggregate/gcp.py
+++ b/cpg_infra/billing_aggregator/aggregate/gcp.py
@@ -159,8 +159,8 @@ def get_billing_data(start: datetime, end: datetime):
         WHERE DATE_TRUNC(usage_end_time, DAY) BETWEEN @start AND @end
         -- The following is to limit full scan to only aprox time period +/- 60 days
         AND DATE_TRUNC(_PARTITIONTIME, DAY) BETWEEN
-            TIMESTAMP(DATETIME_ADD(@start, INTERVAL -60 DAY)) AND
-            TIMESTAMP(DATETIME_ADD(@end, INTERVAL 60 DAY))
+            TIMESTAMP(DATETIME_ADD(@start, INTERVAL -@days_filter DAY)) AND
+            TIMESTAMP(DATETIME_ADD(@end, INTERVAL @days_filter DAY))
         AND project.id NOT IN UNNEST(@exclude)
     """
     exclude_projects = [utils.SEQR_PROJECT_ID, utils.ES_INDEX_PROJECT_ID]
@@ -169,6 +169,11 @@ def get_billing_data(start: datetime, end: datetime):
             bq.ScalarQueryParameter('start', 'STRING', start.strftime('%Y-%m-%d')),
             bq.ScalarQueryParameter('end', 'STRING', end.strftime('%Y-%m-%d')),
             bq.ArrayQueryParameter('exclude', 'STRING', exclude_projects),
+            bq.ScalarQueryParameter(
+                'days_filter',
+                'INT64',
+                utils.BQ_LARGE_PERIOD_FILTER,
+            ),
         ],
     )
 

--- a/cpg_infra/billing_aggregator/aggregate/gcp.py
+++ b/cpg_infra/billing_aggregator/aggregate/gcp.py
@@ -144,6 +144,11 @@ def get_billing_data(start: datetime, end: datetime):
     Return results as a dataframe
     """
 
+    # BQ table GCP_BILLING_BQ_TABLE is partition
+    # by the time records have been exported (_PARTITIONTIME)
+    # We need to limit dataset by _PARTITIONTIME to reduce cost
+    # We need to extend the range to ensure we get all the data
+    # 60 days is a safe buffer and cut the cost significantly comparing to full scan
     _query = f"""
         SELECT
             service, sku, usage_start_time, usage_end_time, project,
@@ -152,7 +157,11 @@ def get_billing_data(start: datetime, end: datetime):
             invoice, cost_type, adjustment_info
         FROM `{utils.GCP_BILLING_BQ_TABLE}`
         WHERE DATE_TRUNC(usage_end_time, DAY) BETWEEN @start AND @end
-            AND project.id NOT IN UNNEST(@exclude)
+        -- The following is to limit full scan to only aprox time period +/- 60 days
+        AND DATE_TRUNC(_PARTITIONTIME, DAY) BETWEEN
+            TIMESTAMP(DATETIME_ADD(@start, INTERVAL -60 DAY)) AND
+            TIMESTAMP(DATETIME_ADD(@end, INTERVAL 60 DAY))
+        AND project.id NOT IN UNNEST(@exclude)
     """
     exclude_projects = [utils.SEQR_PROJECT_ID, utils.ES_INDEX_PROJECT_ID]
     job_config = bq.QueryJobConfig(

--- a/cpg_infra/billing_aggregator/aggregate/requirements.txt
+++ b/cpg_infra/billing_aggregator/aggregate/requirements.txt
@@ -8,5 +8,7 @@ google-api-python-client==2.79.0
 google-cloud-bigquery==3.6.0
 google-cloud-secret-manager==2.15.1
 google-cloud-logging==3.5.0
+# python 3.8+ and numpy2 issues https://github.com/numpy/numpy/issues/26710
+numpy<2.0.0
 pandas==1.5.3
 pandas-gbq==0.19.1

--- a/cpg_infra/billing_aggregator/aggregate/seqr.py
+++ b/cpg_infra/billing_aggregator/aggregate/seqr.py
@@ -347,7 +347,11 @@ def migrate_entries_from_bq(
             credits, invoice, cost_type, adjustment_info
         FROM `{utils.GCP_BILLING_BQ_TABLE}`
         WHERE DATE_TRUNC(usage_end_time, DAY) BETWEEN @start AND @end
-            AND project.id IN UNNEST(@projects)
+        -- The following is to limit full scan to only aprox time period +/- 60 days
+        AND DATE_TRUNC(_PARTITIONTIME, DAY) BETWEEN
+            TIMESTAMP(DATETIME_ADD(@start, INTERVAL -60 DAY)) AND
+            TIMESTAMP(DATETIME_ADD(@end, INTERVAL 60 DAY))
+        AND project.id IN UNNEST(@projects)
         ORDER BY usage_start_time
     """
 

--- a/cpg_infra/billing_aggregator/aggregate/seqr.py
+++ b/cpg_infra/billing_aggregator/aggregate/seqr.py
@@ -349,8 +349,8 @@ def migrate_entries_from_bq(
         WHERE DATE_TRUNC(usage_end_time, DAY) BETWEEN @start AND @end
         -- The following is to limit full scan to only aprox time period +/- 60 days
         AND DATE_TRUNC(_PARTITIONTIME, DAY) BETWEEN
-            TIMESTAMP(DATETIME_ADD(@start, INTERVAL -60 DAY)) AND
-            TIMESTAMP(DATETIME_ADD(@end, INTERVAL 60 DAY))
+            TIMESTAMP(DATETIME_ADD(@start, INTERVAL -@days_filter DAY)) AND
+            TIMESTAMP(DATETIME_ADD(@end, INTERVAL @days_filter DAY))
         AND project.id IN UNNEST(@projects)
         ORDER BY usage_start_time
     """
@@ -361,6 +361,11 @@ def migrate_entries_from_bq(
             bq.ScalarQueryParameter('start', 'STRING', istart.strftime('%Y-%m-%d')),
             bq.ScalarQueryParameter('end', 'STRING', iend.strftime('%Y-%m-%d')),
             bq.ArrayQueryParameter('projects', 'STRING', projects),
+            bq.ScalarQueryParameter(
+                'days_filter',
+                'INT64',
+                utils.BQ_LARGE_PERIOD_FILTER,
+            ),
         ],
     )
 

--- a/cpg_infra/billing_aggregator/aggregate/utils.py
+++ b/cpg_infra/billing_aggregator/aggregate/utils.py
@@ -914,7 +914,6 @@ def upsert_aggregated_dataframe_into_bigquery(
     # https://cloud.google.com/bigquery/docs/parameterized-queries
     if '`' in table:
         raise ValueError(f'Table name ({table}) cannot contain backticks')
-
     _query = f"""
         SELECT id FROM {table}
         WHERE id IN UNNEST(@ids)
@@ -923,7 +922,6 @@ def upsert_aggregated_dataframe_into_bigquery(
         AND DATE_TRUNC(usage_end_time, DAY) BETWEEN
             TIMESTAMP(DATETIME_ADD(@window_start, INTERVAL -60 DAY)) AND
             TIMESTAMP(DATETIME_ADD(@window_end, INTERVAL 60 DAY))
-        ORDER BY topic
     """  # noqa: S608
     job_config = bq.QueryJobConfig(
         query_parameters=[

--- a/cpg_infra/billing_aggregator/aggregate/utils.py
+++ b/cpg_infra/billing_aggregator/aggregate/utils.py
@@ -928,7 +928,7 @@ def upsert_aggregated_dataframe_into_bigquery(
         -- give a +-10 day buffer
         AND DATE_TRUNC(usage_end_time, DAY) BETWEEN
             TIMESTAMP(DATETIME_ADD(@window_start, INTERVAL -@days_filter DAY)) AND
-            TIMESTAMP(DATETIME_ADD(@window_end, INTERVAL days_filter DAY))
+            TIMESTAMP(DATETIME_ADD(@window_end, INTERVAL @days_filter DAY))
     """  # noqa: S608
     job_config = bq.QueryJobConfig(
         query_parameters=[

--- a/cpg_infra/billing_aggregator/aggregate/utils.py
+++ b/cpg_infra/billing_aggregator/aggregate/utils.py
@@ -918,10 +918,10 @@ def upsert_aggregated_dataframe_into_bigquery(
         SELECT id FROM {table}
         WHERE id IN UNNEST(@ids)
         -- usage_end_time might not be exactly aligned with start/end date
-        -- give a +-60 day buffer
+        -- give a +-10 day buffer
         AND DATE_TRUNC(usage_end_time, DAY) BETWEEN
-            TIMESTAMP(DATETIME_ADD(@window_start, INTERVAL -60 DAY)) AND
-            TIMESTAMP(DATETIME_ADD(@window_end, INTERVAL 60 DAY))
+            TIMESTAMP(DATETIME_ADD(@window_start, INTERVAL -10 DAY)) AND
+            TIMESTAMP(DATETIME_ADD(@window_end, INTERVAL 10 DAY))
     """  # noqa: S608
     job_config = bq.QueryJobConfig(
         query_parameters=[
@@ -1421,10 +1421,10 @@ def retrieve_stored_ids(
     _query = f"""
         SELECT id FROM `{table}`
         -- usage_end_time might not be exactly aligned with start/end date
-        -- give a +- 60 day buffer
+        -- give a +- 10 day buffer
         WHERE DATE_TRUNC(usage_end_time, DAY) BETWEEN
-            TIMESTAMP(DATETIME_ADD(@window_start, INTERVAL -60 DAY)) AND
-            TIMESTAMP(DATETIME_ADD(@window_end, INTERVAL 60 DAY))
+            TIMESTAMP(DATETIME_ADD(@window_start, INTERVAL -10 DAY)) AND
+            TIMESTAMP(DATETIME_ADD(@window_end, INTERVAL 10 DAY))
         AND id LIKE '{service_id}-%';
     """  # noqa: S608 both tables and service_id are checked for validity
 


### PR DESCRIPTION
This change:
1. Optimise BQ queries, which did not use the benefit of partitions. Would lower the cost of running the queries.
2. Some of the filters were too restrict, esp. when checking existing ids by usage_end_time, this is fixing bug with some random duplicated records.
3. pin numpy to <2, as some versions of python have issue with version 2.0 as mentioned here: https://github.com/numpy/numpy/issues/26710


