### PR TITLE
[gcp-cost-control] Fix: Use the archive object name

### DIFF
--- a/cpg_infra/billing_aggregator/driver.py
+++ b/cpg_infra/billing_aggregator/driver.py
@@ -183,7 +183,7 @@ class BillingAggregator(CpgInfrastructurePlugin):
             source=gcp.cloudfunctionsv2.FunctionBuildConfigSourceArgs(
                 storage_source=gcp.cloudfunctionsv2.FunctionBuildConfigSourceStorageSourceArgs(
                     bucket=self.source_bucket.name,
-                    object=source_archive,
+                    object=source_archive.name,
                 ),
             ),
         )


### PR DESCRIPTION
Following the other pattern, I think it's supposed to use the `.name.`
Testing this locally, it looks like it should be fine