### PR TITLE
Pin grpcio to reduce logging

### DIFF
--- a/cpg_infra/billing_aggregator/gcp_cost_report_slack_bot/requirements.txt
+++ b/cpg_infra/billing_aggregator/gcp_cost_report_slack_bot/requirements.txt
@@ -5,3 +5,5 @@ flask<3.0,>=1.0
 functions-framework
 slackclient
 pytz
+# https://github.com/grpc/grpc/issues/37222
+grpcio==1.60.1 


### PR DESCRIPTION
https://centrepopgen.slack.com/archives/C0236RXT54J/p1723412715236259?thread_ts=1723330810.902589&cid=C0236RXT54J

I can't replicate locally, but it might be due to a change to grpcio: 
- https://github.com/grpc/grpc/issues/37178#issuecomment-2227719358
- https://github.com/grpc/grpc/issues/37222

I cannot for the life of me work out how to find the version of grpcio in the cloud functions container - I've tried looking up the build logs, running the container but doesn't seem to get me anywhere.