### PR TITLE
Increase billing aggregation timeout to max possible for HTTP cloud functions.

### DIFF
--- a/cpg_infra/billing_aggregator/driver.py
+++ b/cpg_infra/billing_aggregator/driver.py
@@ -327,13 +327,13 @@ class BillingAggregator(CpgInfrastructurePlugin):
 
             if function == 'hail':
                 memory = '3Gi'
-                # hail loading might take more than default 9 minutes
-                timeout = 900
+                # max possible timeout is 1H for HTTP function
+                timeout = 3600
             if function == 'seqr':
                 # seqr needs 4GB of memory
                 memory = '4Gi'
-                # seqr loading takes more than 9 minutes
-                timeout = 1800
+                # max possible timeout is 1H for HTTP function
+                timeout = 3600
 
             # Create the function, the trigger and subscription.
             fxn = self.create_cloud_function(


### PR DESCRIPTION
Increasing timeout for both aggregate function to max possible 1 hour.
We had alert for a job failed overnight.
It was an instance of 1230 hail batches being executed in 4hrs timeframe, billing aggregation timeout of 15 mins only manged to process 30% of them, therefore increased timeout to 60 mins.

The next stage, if in the future this is not going to be sufficient we can change the frequency from every 2hrs processing of 4 hrs block to load billing every hour for the 2 hrs block.