### PR TITLE
New AR-config-viewer group

### DIFF
--- a/cpg_infra/driver.py
+++ b/cpg_infra/driver.py
@@ -2545,11 +2545,7 @@ class CPGDatasetCloudInfrastructure:
 
     @cached_property
     def config_viewer_group(self):
-        return self.group_provider.create_group(
-            self.common_gcp_infra,
-            cache_members=False,
-            name='analysis-runner-config-viewers-group',
-        )
+        return self.create_group('analysis-runner-config-viewers-group')
 
     def setup_analysis_runner(self):
         self.setup_analysis_runner_config_access()
@@ -2568,7 +2564,6 @@ class CPGDatasetCloudInfrastructure:
         )
 
     def setup_analysis_runner_config_access(self):
-        
         if isinstance(self.infra, GcpInfrastructure):
             assert self.config.gcp
             bucket = self.config.gcp.config_bucket_name
@@ -2583,7 +2578,7 @@ class CPGDatasetCloudInfrastructure:
         # create on parent analysis-runner-config-viewer-group
         # and assign bucket READ permissions to it
         self.infra.add_member_to_bucket(
-            f'analysis-runner-config-viewers',
+            'analysis-runner-config-viewers',
             bucket=bucket,  # ANALYSIS_RUNNER_CONFIG_BUCKET_NAME,
             member=self.config_viewer_group,
             membership=BucketMembership.READ,

--- a/cpg_infra/driver.py
+++ b/cpg_infra/driver.py
@@ -2543,6 +2543,14 @@ class CPGDatasetCloudInfrastructure:
     # endregion NOTEBOOKS
     # region ANALYSIS RUNNER
 
+    @cached_property
+    def config_viewer_group(self):
+        return self.group_provider.create_group(
+            self.common_gcp_infra,
+            cache_members=False,
+            name='analysis-runner-config-viewers-group',
+        )
+
     def setup_analysis_runner(self):
         self.setup_analysis_runner_config_access()
 
@@ -2560,20 +2568,38 @@ class CPGDatasetCloudInfrastructure:
         )
 
     def setup_analysis_runner_config_access(self):
+        
+        if isinstance(self.infra, GcpInfrastructure):
+            assert self.config.gcp
+            bucket = self.config.gcp.config_bucket_name
+        elif isinstance(self.infra, AzureInfra):
+            assert self.config.azure
+            bucket = self.config.azure.config_bucket_name
+        else:
+            raise ValueError(
+                f'Bucket could not be determined for {self.infra.name()}',
+            )
+
+        # create on parent analysis-runner-config-viewer-group
+        # and assign bucket READ permissions to it
+        self.infra.add_member_to_bucket(
+            f'analysis-runner-config-viewers',
+            bucket=bucket,  # ANALYSIS_RUNNER_CONFIG_BUCKET_NAME,
+            member=self.config_viewer_group,
+            membership=BucketMembership.READ,
+        )
+
         keys = {'analysis-group': self.analysis_group, **self.access_level_groups}
 
         for key, group in keys.items():
-            if isinstance(self.infra, GcpInfrastructure):
-                assert self.config.gcp
-                bucket = self.config.gcp.config_bucket_name
-            elif isinstance(self.infra, AzureInfra):
-                assert self.config.azure
-                bucket = self.config.azure.config_bucket_name
-            else:
-                raise ValueError(
-                    f'Bucket could not be determined for {self.infra.name()}',
-                )
+            # each of the analysis-group will be added to the parent analysis-runner-config-viewer-group
+            # instead of directly to bucket, to prevent hitting hard GCP 250 limits for member groups per resource
+            self.config_viewer_group.add_member(
+                f'{key}-analysis-runner-config-viewer-group',
+                group,
+            )
 
+            # TODO - remove once tested with config_viewer_group
             self.infra.add_member_to_bucket(
                 f'{key}-analysis-runner-config-viewer',
                 bucket=bucket,  # ANALYSIS_RUNNER_CONFIG_BUCKET_NAME,


### PR DESCRIPTION
This new group is attached to cpg-config bucket.
All the analysis groups will be added as members, instead of directly attached to cpg-config bucket.
This will prevents 250 hard GCP limit on attached groups per resource we are currently experiencing.
Deployment will be done in steps.

1. Creating new group and attach all the existing analysis groups to it. (this PR)
2. Test, manually remove fewgenoms ar-groups from the cpg-config bucket and and submit a batch via AR, check for any permissions issues
3. If test is successful, then remove code on line 2603 as per [TODO comment](https://github.com/populationgenomics/cpg-infrastructure/blob/7985ece94fca4c63e2b2306c8aaee7e68e1f4ce1/cpg_infra/driver.py#L2603)