### PR TITLE
Increasing hail RAM to 4GB, pandas upgrade.

### DIFF
--- a/cpg_infra/billing_aggregator/aggregate/requirements.txt
+++ b/cpg_infra/billing_aggregator/aggregate/requirements.txt
@@ -9,5 +9,5 @@ google-cloud-bigquery==3.11.4
 google-cloud-secret-manager==2.15.1
 google-cloud-logging==3.5.0
 numpy>=1.23.2
-pandas==2.0.1
+pandas==2.2.3
 pandas-gbq==0.23.1

--- a/cpg_infra/billing_aggregator/driver.py
+++ b/cpg_infra/billing_aggregator/driver.py
@@ -325,12 +325,8 @@ class BillingAggregator(CpgInfrastructurePlugin):
             cpu = 1
             timeout = 540
 
-            if function == 'hail':
-                memory = '3Gi'
-                # max possible timeout is 1H for HTTP function
-                timeout = 3600
-            if function == 'seqr':
-                # seqr needs 4GB of memory
+            if function in ['hail', 'seqr']:
+                # batch specific aggreg functions needs 4GB of memory
                 memory = '4Gi'
                 # max possible timeout is 1H for HTTP function
                 timeout = 3600


### PR DESCRIPTION
Hail aggregate function needs more than 3GB for processing, older pandas has issue with the latest numpy, pinned to a different version.