### PR TITLE
Updating resource pulumi name for ar-config groups.

### DIFF
--- a/cpg_infra/driver.py
+++ b/cpg_infra/driver.py
@@ -2606,7 +2606,7 @@ class CPGDatasetCloudInfrastructure:
             # each of the analysis-group will be added to the parent analysis-runner-config-viewer-group
             # instead of directly to bucket, to prevent hitting hard GCP 250 limits for member groups per resource
             self.root.config_viewer_group.add_member(
-                f'{key}-analysis-runner-config-viewer-group',
+                f'{group.display_name}-analysis-runner-config-viewer-group',
                 group,
             )
 


### PR DESCRIPTION
After deploy and checking the members of the new AR-config group, I have noticed it contains only the first dataset, rest is missing.
This is bug is because the value key is the same across dataset.
Made a change to depends pulumi resource name on the group name, which is what we want.
