### PR TITLE
Fix name of the group for pulumi resource.

### DIFF
--- a/cpg_infra/driver.py
+++ b/cpg_infra/driver.py
@@ -2606,7 +2606,7 @@ class CPGDatasetCloudInfrastructure:
             # each of the analysis-group will be added to the parent analysis-runner-config-viewer-group
             # instead of directly to bucket, to prevent hitting hard GCP 250 limits for member groups per resource
             self.root.config_viewer_group.add_member(
-                f'{group.display_name}-analysis-runner-config-viewer-group',
+                f'{group.name}-analysis-runner-config-viewer-group',
                 group,
             )
 


### PR DESCRIPTION
Group does not have display_name attribute, only name.
It is our Group class and not gcp.cloudidentity.Group, which has both.