### PR TITLE
Billing aggregation timeout exception

### DIFF
--- a/cpg_infra/billing_aggregator/aggregate/utils.py
+++ b/cpg_infra/billing_aggregator/aggregate/utils.py
@@ -191,7 +191,9 @@ async def async_retry_transient_get_json_request(
                     resp.raise_for_status()
                     return await resp.json()
             # pylint: disable=broad-except
-            except aiohttp.ClientError as e:
+            except Exception as e:
+                # reason for generic exception here is
+                # we can control which exception to catch listed in errors
                 last_exception = e
                 if not isinstance(e, errors):
                     raise

--- a/cpg_infra/driver.py
+++ b/cpg_infra/driver.py
@@ -2591,7 +2591,7 @@ class CPGDatasetCloudInfrastructure:
     def setup_analysis_runner_config_access(self):
         keys = {'analysis-group': self.analysis_group, **self.access_level_groups}
 
-        for key, group in keys.items():
+        for _key, group in keys.items():
             # each of the analysis-group will be added to the parent analysis-runner-config-viewer-group
             # instead of directly to bucket, to prevent hitting hard GCP 250 limits for member groups per resource
             self.root.config_viewer_group.add_member(


### PR DESCRIPTION
There has been change 2 months ago which removed catching asyncio.TimeoutError,
causing seqr aggregation to randomly fail.
I had rollback to generic Exception as it was prior to 'Migrate slack bot' PR.