### PR TITLE
Billing aggregation improvements

### DIFF
--- a/cpg_infra/billing_aggregator/aggregate/utils.py
+++ b/cpg_infra/billing_aggregator/aggregate/utils.py
@@ -107,7 +107,7 @@ DEFAULT_RANGE_INTERVAL = timedelta(hours=int(os.getenv('DEFAULT_INTERVAL_HOURS',
 # To avoid full scan, we limit the query to +/- XY days
 # For the queries where we return Ids, small period used to limit long running jobs (we compare on usage end date)
 # For other queries we use large period, to be on safe side to not miss any data
-BQ_SMALL_PERIOD_FILTER = 2
+BQ_SMALL_PERIOD_FILTER = 1
 BQ_LARGE_PERIOD_FILTER = 60
 
 SEQR_PROJECT_ID = 'seqr-308602'
@@ -928,7 +928,7 @@ def upsert_aggregated_dataframe_into_bigquery(
         SELECT id FROM {table}
         WHERE id IN UNNEST(@ids)
         -- usage_end_time might not be exactly aligned with start/end date
-        -- give a +-10 day buffer
+        -- give a +-1 day buffer
         AND DATE_TRUNC(usage_end_time, DAY) BETWEEN
             TIMESTAMP(DATETIME_ADD(@window_start, INTERVAL -@days_filter DAY)) AND
             TIMESTAMP(DATETIME_ADD(@window_end, INTERVAL @days_filter DAY))
@@ -1441,7 +1441,7 @@ def retrieve_stored_ids(
     _query = f"""
         SELECT id FROM `{table}`
         -- usage_end_time might not be exactly aligned with start/end date
-        -- give a +- 10 day buffer
+        -- give a +- 1 day buffer
         WHERE DATE_TRUNC(usage_end_time, DAY) BETWEEN
             TIMESTAMP(DATETIME_ADD(@window_start, INTERVAL -@days_filter DAY)) AND
             TIMESTAMP(DATETIME_ADD(@window_end, INTERVAL @days_filter DAY))

--- a/cpg_infra/billing_aggregator/driver.py
+++ b/cpg_infra/billing_aggregator/driver.py
@@ -329,9 +329,15 @@ class BillingAggregator(CpgInfrastructurePlugin):
                 # max possible timeout is 1H for HTTP functions
                 timeout = 3600
 
-            if function in ['hail', 'seqr']:
-                # batch specific aggreg functions needs 5GB of memory
-                memory = '5Gi'
+            if function in ['seqr']:
+                # seqr specific aggreg function needs 4GB of memory
+                memory = '4Gi'
+
+            if function in ['hail']:
+                # hail specific aggreg function needs over 4GB of memory
+                # max 4GB per 1 CPU, we need more than 4GB therefore 2 CPUs
+                cpu = 2
+                memory = '8Gi'
 
             # Create the function, the trigger and subscription.
             fxn = self.create_cloud_function(

--- a/cpg_infra/billing_aggregator/driver.py
+++ b/cpg_infra/billing_aggregator/driver.py
@@ -325,6 +325,8 @@ class BillingAggregator(CpgInfrastructurePlugin):
             cpu = 1
             timeout = 540
 
+            # TODO: We should consider moving function specific cpu/memory/timeout values to config
+
             if function in ['hail', 'seqr', 'gcp']:
                 # max possible timeout is 1H for HTTP functions
                 timeout = 3600
@@ -335,9 +337,9 @@ class BillingAggregator(CpgInfrastructurePlugin):
 
             if function in ['hail']:
                 # hail specific aggreg function needs over 4GB of memory
-                # max 4GB per 1 CPU, we need more than 4GB therefore 2 CPUs
-                cpu = 2
-                memory = '8Gi'
+                # max 4GB per 1 CPU, for extreme busy days 16GB is needed
+                cpu = 4
+                memory = '16Gi'
 
             # Create the function, the trigger and subscription.
             fxn = self.create_cloud_function(

--- a/cpg_infra/billing_aggregator/driver.py
+++ b/cpg_infra/billing_aggregator/driver.py
@@ -331,15 +331,9 @@ class BillingAggregator(CpgInfrastructurePlugin):
                 # max possible timeout is 1H for HTTP functions
                 timeout = 3600
 
-            if function in ['seqr']:
-                # seqr specific aggreg function needs 4GB of memory
+            if function in ['seqr', 'hail']:
+                # seqr & hail specific aggreg function needs 4GB of memory
                 memory = '4Gi'
-
-            if function in ['hail']:
-                # hail specific aggreg function needs over 4GB of memory
-                # max 4GB per 1 CPU, for extreme busy days 16GB is needed
-                cpu = 4
-                memory = '16Gi'
 
             # Create the function, the trigger and subscription.
             fxn = self.create_cloud_function(
@@ -357,9 +351,7 @@ class BillingAggregator(CpgInfrastructurePlugin):
                     # 'SETUP_GCP_LOGGING': 'true',
                     'GCP_AGGREGATE_DEST_TABLE': self.config.billing.aggregator.destination_bq_table,
                     'GCP_BILLING_SOURCE_TABLE': self.config.billing.gcp.source_bq_table,
-                    # cover at least the previous period as well
-                    'DEFAULT_INTERVAL_HOURS': self.config.billing.aggregator.interval_hours
-                    * 2,
+                    'DEFAULT_INTERVAL_HOURS': self.config.billing.aggregator.interval_hours,
                     'BILLING_PROJECT_ID': self.config.billing.gcp.project_id,
                 },
                 timeout=timeout,


### PR DESCRIPTION
This PR contains improvements regarding RAM usage, before we filter only on partition (by day +-1), which for heavy days produce huge amount of records causing the aggregation run out of RAM.
Extra filter has been added to filter further by usage_end_date, which significantly lower RAM usage.

From simple testing only around 1GB would be needed, but will keep it at 4GB for time being, we can check the usage in a few weeks and if we found 4GB is too much we can lower it. From cost perspective this is not going to make much difference.