### PR TITLE
Fixed few types issues when calling BQ.

### DIFF
--- a/cpg_infra/billing_aggregator/aggregate/gcp.py
+++ b/cpg_infra/billing_aggregator/aggregate/gcp.py
@@ -126,8 +126,8 @@ async def migrate_billing_data(start, end, dataset_to_topic) -> int:
         )
         result += utils.upsert_aggregated_dataframe_into_bigquery(
             dataframe=chunk,
-            window_start=start.date(),
-            window_end=end.date(),
+            window_start=start,
+            window_end=end,
         )
 
     return result

--- a/cpg_infra/billing_aggregator/aggregate/utils.py
+++ b/cpg_infra/billing_aggregator/aggregate/utils.py
@@ -1023,12 +1023,12 @@ def get_currency_conversion_rate_for_time(time: datetime) -> float:
                 bq.ScalarQueryParameter('invoice_month', 'STRING', key),
                 bq.ScalarQueryParameter(
                     'window_start',
-                    'DATETIME',
+                    'TIMESTAMP',
                     window_start,
                 ),
                 bq.ScalarQueryParameter(
                     'window_end',
-                    'DATETIME',
+                    'TIMESTAMP',
                     window_end,
                 ),
                 bq.ScalarQueryParameter(
@@ -1038,6 +1038,7 @@ def get_currency_conversion_rate_for_time(time: datetime) -> float:
                 ),
             ],
         )
+
         query_result = (
             get_bigquery_client().query(query, job_config=job_config).result()
         )


### PR DESCRIPTION
Fixed few issues after deploying last PR.:

1. TIMESTAMP and DATETIME are not compatible when using BETWEEN operator in BQ, need to provide the right types for the query.
2. GCP aggregation was using date(), where what we really need is datetime. Had remove the casting datetime to date.
3. Seqr had one more issue the filter was too wide when collecting data after making optimisation with previous PR:
https://github.com/populationgenomics/cpg-infrastructure/pull/278

Have tested all 3 functions.

