### PR TITLE
Temporarily add workflow.default_jar_spec_revision to infrastructure.toml

### DIFF
--- a/cpg_infra/driver.py
+++ b/cpg_infra/driver.py
@@ -631,6 +631,11 @@ class CPGInfrastructure:
             # nest in .infrastructure
             d = {'infrastructure': dict(zip(keys, values))}
 
+            # JohnM 10 Dec 2024: Temporarily override QoB JAR to avoid ballooning hail costs
+            # cc7d0f is 0.2.132 with retry-all-400-errors (SET-261) and no 20million fixes (SET-247)
+            v132_retry_no20million = 'cc7d0fa48bd88b10b8c1c7315d9604ee855693e7'
+            d['workflow'] = {'default_jar_spec_revision': v132_retry_no20million}
+
             return dict_to_toml(d)
 
         infra_config = pulumi.Output.all(*[v[1] for v in items]).apply(_build_config)


### PR DESCRIPTION
Until upstream Hail releases proper fixes for SET-261 and especially SET-247, we need to override the QoB JAR file always.