### PR TITLE
Ignore new GCP fields during billing aggregation.

### DIFF
--- a/cpg_infra/billing_aggregator/aggregate/utils.py
+++ b/cpg_infra/billing_aggregator/aggregate/utils.py
@@ -883,6 +883,10 @@ def upsert_rows_into_bigquery(
         # Insert the new rows
         job_config = bq.LoadJobConfig()
         job_config.source_format = bq.SourceFormat.NEWLINE_DELIMITED_JSON
+
+        # there is at least one new field passed from GCP billing table, not present in metamist schema:
+        # invoice.publisher_type
+        job_config.ignore_unknown_values = True
         job_config.schema = get_formatted_bq_schema()
 
         j = '\n'.join(json.dumps(o) for o in filtered_obj)


### PR DESCRIPTION
It seems GCP added new field into invoice, called 'invoice.publisher_type'.
Our aggregated table does not contain it and BQ had failed to load it. 
This only happened so far when running locally and it is a bit of mystery why the loading is not failing yet on production.
Adding ignore for new fields makes it more future resilient, in case Google add any new fields to their billing records.