### PR TITLE
Upgrade pulumi-gcp to version where create_ignore_already_exists exists

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ google-api-python-client==2.*
 google-auth==2.*
 pulumi-azure-native==2.21.2
 pulumi-azuread==5.46.0
-pulumi-gcp==7.2.2
+pulumi-gcp~=7.6
 pulumi==3.96.2
 pytest==8.3.2
 toml-sort


### PR DESCRIPTION
This param wasn't included until v7.6 of pulumi-gcp where the terraform bridge was updated to 5.12.0
https://github.com/pulumi/pulumi-gcp/pull/1542
https://github.com/pulumi/pulumi-gcp/releases/tag/v7.6.0

We could update to an even more up-to-date version but trying to avoid compatibility problems with other dependencies