### PR TITLE
Add images_location_format entry recording production images path

### DIFF
--- a/cpg_infra/config/config.py
+++ b/cpg_infra/config/config.py
@@ -84,6 +84,7 @@ class CPGInfrastructureConfig(DeserializableDataclass):
             git_credentials_secret_name: str | None = None
             git_credentials_secret_project: str | None = None
             wheel_bucket_name: str | None = None
+            images_location_format: str | None = None
 
         @dataclasses.dataclass(frozen=True)
         class Azure(DeserializableDataclass):

--- a/cpg_infra/driver.py
+++ b/cpg_infra/driver.py
@@ -617,6 +617,10 @@ class CPGInfrastructure:
                 output['git_credentials_secret_project'] = (
                     self.config.hail.gcp.git_credentials_secret_project
                 )
+            if self.config.hail.gcp.images_location_format is not None:
+                output['images_location_format'] = (
+                    self.config.hail.gcp.images_location_format
+                )
 
         return output
 


### PR DESCRIPTION
Made available in the config as `infrastructure.images_location_format`, similarly to `git_credentials_secret_name`.