### PR TITLE
Update QoB JAR override to be 0.2.134-based and include 400logging

### DIFF
--- a/cpg_infra/driver.py
+++ b/cpg_infra/driver.py
@@ -632,10 +632,9 @@ class CPGInfrastructure:
             d = {'infrastructure': dict(zip(keys, values))}
 
             # JohnM 10 Dec 2024: Temporarily override QoB JAR to avoid ballooning hail costs
-            # 07de0a408 is 0.2.133 with a StreamReadConstraints maxStringLength fix cherry-picked
-            # from upcoming upstream and SET-261-log-400-errors, built via a CI deploy batch
-            v133_retry_via_ci = '07de0a408acaba693dd94b115eac6bbacae1a6b9'
-            d['workflow'] = {'default_jar_spec_revision': v133_retry_via_ci}
+            # 2bb197d63 is 0.2.134 with SET-261-log-400-errors, built via a CI deploy batch
+            v134_retry_via_ci = '2bb197d63afd58f9452af306e0eb14d6924d0019'
+            d['workflow'] = {'default_jar_spec_revision': v134_retry_via_ci}
 
             return dict_to_toml(d)
 


### PR DESCRIPTION
Update the QoB JAR override again, primarily to make it correspond to the deployed 0.2.134 hail release. This is a followup to #287, #288, and #292. We are nearly at a point where we won't need or want to override the QoB JAR by default anymore.

Use a QoB JAR built via a Hail CI deploy batch. This includes release 0.2.134 (which fixes the "20 million string length" issue) and retains our added logging to help identify the intermittent 400 Bad Request errors previously encountered locally (SET-261).

The selected commit, 2bb197d63afd58f9452af306e0eb14d6924d0019, is 0.2.134.cpg1 as tagged for CPG image building purposes (cf populationgenomics/images#200 and populationgenomics/images#201).