### PR TITLE
Increase RAM for Seqr billing aggregate cloud run from 8GB to 12GB.

### DIFF
--- a/cpg_infra/billing_aggregator/driver.py
+++ b/cpg_infra/billing_aggregator/driver.py
@@ -331,11 +331,17 @@ class BillingAggregator(CpgInfrastructurePlugin):
                 # max possible timeout is 1H for HTTP functions
                 timeout = 3600
 
-            if function in ['seqr', 'hail']:
-                # seqr & hail specific aggreg function needs over 4GB of memory
+            if function == 'hail':
+                # hail specific aggreg function needs over 4GB of memory
                 # 4GB per 1x cpu
                 cpu = 2
                 memory = '8Gi'
+
+            if function == 'seqr':
+                # seqr specific aggreg function needs over 8GB of memory
+                # 4GB per 1x cpu
+                cpu = 3
+                memory = '12Gi'
 
             # Create the function, the trigger and subscription.
             fxn = self.create_cloud_function(


### PR DESCRIPTION
After speeding up the seqr aggregation we can now load more data, that however is hitting the 8GB RAM ceiling.
RAM is relatively cheap, current setup costing us 15USD per month for both compute and RAM in billing project.