### PR TITLE
Updating CPU count for seqr billing aggregator function.

### DIFF
--- a/cpg_infra/billing_aggregator/driver.py
+++ b/cpg_infra/billing_aggregator/driver.py
@@ -340,7 +340,7 @@ class BillingAggregator(CpgInfrastructurePlugin):
             if function == 'seqr':
                 # seqr specific aggreg function needs over 8GB of memory
                 # 4GB per 1x cpu
-                cpu = 3
+                cpu = 4
                 memory = '12Gi'
 
             # Create the function, the trigger and subscription.


### PR DESCRIPTION
GCP cloud function CPU amount can be only 1,2,4... number 3 is not accepted.
This PR is fixing it.