### PR TITLE
Change to storage visualisation function.

### DIFF
--- a/storage_visualization/main.py
+++ b/storage_visualization/main.py
@@ -65,7 +65,7 @@ def main():
     # Process the combined output of all jobs to generate a web report.
     treemap_job = batch.new_job(name='treemap')
     prepare_job(treemap_job, clone_repo=True)
-    treemap_job.memory('8Gi')
+    treemap_job.memory('14Gi')
     # just don't show the specific report if it fails
     treemap_job.always_run(True)
     for job in job_output_paths:

--- a/storage_visualization/treemap.py
+++ b/storage_visualization/treemap.py
@@ -56,7 +56,7 @@ def get_parser():
     parser.add_argument(
         '--max-depth',
         help='Maximum folder depth to display',
-        default=3,
+        default=2,
         type=int,
     )
     parser.add_argument(


### PR DESCRIPTION
This PR is addressing the storage visualisation issue:
1. Increase treemap job to 14GB, even hail is already reporting it has 14GB, so might not be needed.
2. Limit error message to just 250 chars, this will prevent the spamming slack channel with large error dumps. 250 is just a random number.
3. After testing the new RC of kaleido, generating image for all 3 levels is still freezing when tested locally.
As one of the possible solution was to use only 2 levels for the image and all 3 levels for the html page. So if people need more details they can follow the link from the Slack message. To avoid double parsing the data and creating 2 copies of rows, this PR is just filtering out dataframe rows by names. Field name contains full path to the stored object, so it just counts number of forward slashes.

