### PR TITLE
SET-463 Add billing aggregation function to run seqr 24h behind.

### DIFF
--- a/cpg_infra/billing_aggregator/aggregate/ica.py
+++ b/cpg_infra/billing_aggregator/aggregate/ica.py
@@ -30,6 +30,7 @@ from typing import (
 import aiohttp
 import functions_framework
 import google.cloud.bigquery as bq
+import numpy as np
 import pandas as pd
 from flask import Request
 
@@ -158,7 +159,9 @@ async def migrate_billing_data(start, end) -> int:
                 'invoice',
                 'cost_type',
             ]
-        ]
+        ].replace(
+            'None', np.nan
+        )  # replace all None with np.NaN os it gets converted to null
 
         # convert to list of dictionaries and insert into BigQuery
         result += utils.upsert_rows_into_bigquery(

--- a/cpg_infra/billing_aggregator/aggregate/seqr24.py
+++ b/cpg_infra/billing_aggregator/aggregate/seqr24.py
@@ -1,0 +1,77 @@
+"""
+This cloud function runs every hour, 24 hours behind the regular seqr.py
+
+Reason for this is Cromwell billing data processed by seqr.py are updated much later
+(more than 5 hours) after seqr finishes its job of migrating data
+
+Reason we need to create a new function and not reused existing is:
+We only allow one cloud function to run in parrallel,
+we need to prevent from inserting duplicated records.
+BQ does not have concept of unigue fields.
+
+This seqr24 basically calls the same seqr code, just start and datime is shifted back 24 hours
+"""
+
+import asyncio
+import logging
+from datetime import datetime, timedelta
+
+import functions_framework
+from flask import Request
+from seqr import RunMode
+from seqr import main as seqr_main
+
+try:
+    from . import utils
+except ImportError:
+    import utils  # type: ignore[no-redef]
+
+logger = utils.logger.getChild('seqr24')
+
+
+async def main(
+    start: datetime | None = None,
+    end: datetime | None = None,
+    mode: RunMode = 'prod',
+    output_path: str | None = None,
+    batch_ids: list[str] | None = None,
+):
+    """Main body function"""
+    logger.info(f'Running Seqr24 Billing Aggregation for [{start}, {end}]')
+    start, end = utils.process_default_start_and_end(start, end)
+    # move 1D (24H) back
+    start = start - timedelta(days=1)
+    end = end - timedelta(days=1)
+    return await seqr_main(start, end, mode, output_path, batch_ids)
+
+
+@functions_framework.http
+def from_request(request: Request):
+    """
+    From request object, get start and end time if present
+    """
+    try:
+        start, end = utils.get_start_and_end_from_request(request)
+    except ValueError as err:
+        logger.warning(err)
+        logger.warning('Defaulting to None')
+        start, end = None, None
+
+    return asyncio.new_event_loop().run_until_complete(main(start, end))
+
+
+if __name__ == '__main__':
+    logger.setLevel(logging.INFO)
+    logging.getLogger('google').setLevel(logging.WARNING)
+    logging.getLogger('google.auth.compute_engine._metadata').setLevel(logging.ERROR)
+    logging.getLogger('asyncio').setLevel(logging.ERROR)
+    logging.getLogger('urllib3').setLevel(logging.WARNING)
+
+    test_start, test_end = None, None
+
+    asyncio.new_event_loop().run_until_complete(
+        main(
+            start=test_start,
+            end=test_end,
+        ),
+    )

--- a/cpg_infra/billing_aggregator/driver.py
+++ b/cpg_infra/billing_aggregator/driver.py
@@ -327,7 +327,7 @@ class BillingAggregator(CpgInfrastructurePlugin):
 
             # TODO: We should consider moving function specific cpu/memory/timeout values to config
 
-            if function in ['hail', 'seqr', 'gcp']:
+            if function in ['hail', 'seqr', 'seqr24', 'gcp']:
                 # max possible timeout is 1H for HTTP functions
                 timeout = 3600
 
@@ -337,7 +337,7 @@ class BillingAggregator(CpgInfrastructurePlugin):
                 cpu = 2
                 memory = '8Gi'
 
-            if function == 'seqr':
+            if function in ['seqr', 'seqr24']:
                 # seqr specific aggreg function needs over 8GB of memory
                 # 4GB per 1x cpu
                 cpu = 4


### PR DESCRIPTION
This PR add a new seqr24 cloud function which migrates GCP billing records from previous day.
Reason behind is to capture billing info for Cromwell jobs as those are updated by GCP much later than the execution of the regular seqr scheduled job. 

Config update to allow this function to run is in this PR:
https://github.com/populationgenomics/cpg-infrastructure-private/pull/542

This PR as well contains small fix for ICA. None gets converted to string, where we need null for the json object.