### PR TITLE
Trim depth of recursion for VDS in storage-vis

### DIFF
--- a/storage_visualization/disk_usage.py
+++ b/storage_visualization/disk_usage.py
@@ -56,8 +56,8 @@ def aggregate_level(name: str) -> str:
         return name[: mt_index + 3]
     if (vds_index := name.find('.vds/')) != -1:
         return name[: vds_index + 4]
-    if (batch_tmp_index := name.rfind('batch-tmp')) != -1:
-        return name[: batch_tmp_index + 9]
+    if (batch_tmp_index := name.rfind('/batch-tmp')) != -1:
+        return name[: batch_tmp_index + 10]
     if (slash_index := name.rfind('/')) != -1:
         return name[:slash_index]
     return ''  # Root level

--- a/storage_visualization/disk_usage.py
+++ b/storage_visualization/disk_usage.py
@@ -54,8 +54,8 @@ def aggregate_level(name: str) -> str:
         return name[: ht_index + 3]
     if (mt_index := name.find('.mt/')) != -1:
         return name[: mt_index + 3]
-    if (mt_index := name.find('.vds/')) != -1:
-        return name[: mt_index + 4]
+    if (vds_index := name.find('.vds/')) != -1:
+        return name[: vds_index + 4]
     if (slash_index := name.rfind('/')) != -1:
         return name[:slash_index]
     return ''  # Root level

--- a/storage_visualization/disk_usage.py
+++ b/storage_visualization/disk_usage.py
@@ -54,6 +54,8 @@ def aggregate_level(name: str) -> str:
         return name[: ht_index + 3]
     if (mt_index := name.find('.mt/')) != -1:
         return name[: mt_index + 3]
+    if (mt_index := name.find('.vds/')) != -1:
+        return name[: mt_index + 4]
     if (slash_index := name.rfind('/')) != -1:
         return name[:slash_index]
     return ''  # Root level

--- a/storage_visualization/disk_usage.py
+++ b/storage_visualization/disk_usage.py
@@ -56,7 +56,7 @@ def aggregate_level(name: str) -> str:
         return name[: mt_index + 3]
     if (vds_index := name.find('.vds/')) != -1:
         return name[: vds_index + 4]
-    if (batch_tmp_index := name.rfind('batch-tmp/')) != -1:
+    if (batch_tmp_index := name.rfind('batch-tmp')) != -1:
         return name[: batch_tmp_index + 9]
     if (slash_index := name.rfind('/')) != -1:
         return name[:slash_index]

--- a/storage_visualization/disk_usage.py
+++ b/storage_visualization/disk_usage.py
@@ -56,6 +56,8 @@ def aggregate_level(name: str) -> str:
         return name[: mt_index + 3]
     if (vds_index := name.find('.vds/')) != -1:
         return name[: vds_index + 4]
+    if (batch_tmp_index := name.rfind('batch-tmp/')) != -1:
+        return name[: batch_tmp_index + 9]
     if (slash_index := name.rfind('/')) != -1:
         return name[:slash_index]
     return ''  # Root level


### PR DESCRIPTION
Our storage plots have gone haywire - from a 5MB HTML file a year ago to 500+MB now, these can't be rendered. 

My suspicion is that the Hail Object detection (highly nested directories) only applies to HT/MT, and was not aware of VDSs. A VDS is a direcotry containing two MTs, but stored as `reference_data` and `variant_data`, so they wouldn't independently be recognised by the `.mt` extension detection. 

This might be the one secret ingredient to make these reports usable again, or there may be some other underlying cause for the bloat, but in either scenario this feels like a good change to make. 