### PR TITLE
Also trim batch-tmp as the top-level diectory in storage-vis

### DIFF
--- a/storage_visualization/disk_usage.py
+++ b/storage_visualization/disk_usage.py
@@ -56,6 +56,8 @@ def aggregate_level(name: str) -> str:
         return name[: mt_index + 3]
     if (vds_index := name.find('.vds/')) != -1:
         return name[: vds_index + 4]
+    if name.startswith('batch-tmp'):
+        return name[:9]
     if (batch_tmp_index := name.rfind('/batch-tmp')) != -1:
         return name[: batch_tmp_index + 10]
     if (slash_index := name.rfind('/')) != -1:


### PR DESCRIPTION
Recall that a blob's name is just the pathname after the bucket, so there is no leading slash before the top-level. D'oh.

We want to catch `…/batch-tmpNNNNNN/…` but not `batch-tmp` within a different directory name (unlikely to be sure!), so we need to handle arbitrary `…/batch-tmp…` and an initial `batch-tmp…` separately.