### PR TITLE
Avoid recent incompatible kaleido 1.0.0 release

### DIFF
--- a/storage_visualization/Dockerfile
+++ b/storage_visualization/Dockerfile
@@ -1,4 +1,5 @@
 FROM australia-southeast1-docker.pkg.dev/analysis-runner/images/driver:latest
 
 # Writing an image in plotly requires the kaleido package.
-RUN pip install kaleido
+# 1.0 requires Chrome and a plotly version that's incompatible with Hail.
+RUN pip install 'kaleido<1.0'


### PR DESCRIPTION
Kaleido 1.0.0 was released on June 20th and [breaks our storage visualisation](https://batch.hail.populationgenomics.org.au/batches/625886/jobs/72) due to

```
Warning: You have Plotly version 5.24.1, which is not compatible with this version of Kaleido (1.0.0).

This means that static image generation (e.g. `fig.write_image()`) will not work.

Please upgrade Plotly to version 6.1.1 or greater, or downgrade Kaleido to version 0.2.1.

…

ValueError: 
Image export using the "kaleido" engine requires the kaleido package,
which can be installed using pip:
    $ pip install -U kaleido
```

The older plotly 5.x is required by Hail, so for now we prefer to continue to use the kaleido 0.2.1 we've previously used rather than upgrade the world.