### PR TITLE
Replacing ARRAY_TO_STRING with REGEXP_REPLACE to include the old style sequencing_groups, where encoded inverted commas are present.

### DIFF
--- a/cpg_infra/billing_aggregator/aggregate/bq/aggregate_daily_extended.sql
+++ b/cpg_infra/billing_aggregator/aggregate/bq/aggregate_daily_extended.sql
@@ -13,7 +13,7 @@ JSON_VALUE(PARSE_JSON(labels, wide_number_mode=>'round'), '$.batch_id') as batch
 JSON_VALUE(PARSE_JSON(labels, wide_number_mode=>'round'), '$.job_id') as job_id,
 JSON_VALUE(PARSE_JSON(labels, wide_number_mode=>'round'), '$.sequencing_type') as sequencing_type,
 JSON_VALUE(PARSE_JSON(labels, wide_number_mode=>'round'), '$.stage') as stage,
-CASE WHEN JSON_QUERY(labels, '$.sequencing_groups') IS NOT NULL THEN ARRAY_TO_STRING(JSON_VALUE_ARRAY(labels, '$.sequencing_groups'), ',')
+CASE WHEN JSON_QUERY(labels, '$.sequencing_groups') IS NOT NULL THEN REGEXP_REPLACE(REPLACE(JSON_VALUE(PARSE_JSON(labels), '$.sequencing_groups'),"'",""), "\\[|\\]", "")
 ELSE COALESCE(JSON_VALUE(PARSE_JSON(labels, wide_number_mode=>'round'), '$.sequencing_group'), JSON_VALUE(PARSE_JSON(labels, wide_number_mode=>'round'), '$.sequencing-group'))
 END as sequencing_group,
 CASE WHEN JSON_QUERY(labels, '$.cohorts') IS NOT NULL THEN ARRAY_TO_STRING(JSON_VALUE_ARRAY(labels, '$.cohorts'), ',') ELSE NULL END as cohorts,

--- a/cpg_infra/billing_aggregator/aggregate/bq/aggregate_job_details.sql
+++ b/cpg_infra/billing_aggregator/aggregate/bq/aggregate_job_details.sql
@@ -3,7 +3,7 @@ AS
 SELECT
     JSON_VALUE(PARSE_JSON(labels, wide_number_mode=>'round'), '$.ar-guid') as ar_guid,
     JSON_VALUE(PARSE_JSON(labels, wide_number_mode=>'round'), '$.batch_id') as batch_id,
-    CASE WHEN JSON_QUERY(labels, '$.sequencing_groups') IS NOT NULL THEN ARRAY_TO_STRING(JSON_VALUE_ARRAY(labels, '$.sequencing_groups'), ',')
+    CASE WHEN JSON_QUERY(labels, '$.sequencing_groups') IS NOT NULL THEN REGEXP_REPLACE(REPLACE(JSON_VALUE(PARSE_JSON(labels), '$.sequencing_groups'),"'",""), "\\[|\\]", "")
     ELSE COALESCE(JSON_VALUE(PARSE_JSON(labels, wide_number_mode=>'round'), '$.sequencing_group'), JSON_VALUE(PARSE_JSON(labels, wide_number_mode=>'round'), '$.sequencing-group'))
     END as sequencing_group,
     CASE WHEN JSON_QUERY(labels, '$.cohorts') IS NOT NULL THEN ARRAY_TO_STRING(JSON_VALUE_ARRAY(labels, '$.cohorts'), ',') ELSE NULL END as cohorts,


### PR DESCRIPTION
This PR is a simple fix to the old style sequencing_groups with encoded inverted commas are present.