### PR TITLE
Add CPGInfrastructureGroup and creation of ad-hoc google groups

### DIFF
--- a/cpg_infra/config/__init__.py
+++ b/cpg_infra/config/__init__.py
@@ -6,6 +6,7 @@ from cpg_infra.config.config import (
     CPGDatasetComponents,
     CPGDatasetConfig,
     CPGInfrastructureConfig,
+    CPGInfrastructureGroup,
     CPGInfrastructureUser,
     GroupName,
     HailAccount,

--- a/cpg_infra/config/config.py
+++ b/cpg_infra/config/config.py
@@ -40,6 +40,15 @@ class CPGInfrastructureUser(DeserializableDataclass):
 
 
 @dataclasses.dataclass(frozen=True)
+class CPGInfrastructureGroup(DeserializableDataclass):
+    """Represents an additional adhoc group under infrastructure management"""
+
+    name: str
+    description: str
+    members: list[MemberKey] = dataclasses.field(default_factory=list)
+
+
+@dataclasses.dataclass(frozen=True)
 class CPGInfrastructureConfig(DeserializableDataclass):
     """
     Configuration that describes all variables required to instantiate the
@@ -264,6 +273,8 @@ class CPGInfrastructureConfig(DeserializableDataclass):
     metamist: Metamist | None = None
     # configuration options for billing + billing aggregation
     billing: Billing | None = None
+    # list of additional adhoc groups under infrastructure management
+    adhoc_groups: list[CPGInfrastructureGroup] | None = None
 
     # When resources are renamed, it can be useful to explicitly apply changes in two
     # phases: delete followed by create; that's opposite of the default create followed by

--- a/cpg_infra/driver.py
+++ b/cpg_infra/driver.py
@@ -369,6 +369,9 @@ class CPGInfrastructure:
         # storage buckets, metamist and hail users etc.
         self.deploy_datasets()
 
+        # Deploy managed adhoc assets that are not associated with datasets.
+        self.deploy_adhoc()
+
         plugins = get_plugins()
         initialised_plugins = []
         for plugin_name in self.config.plugins_enabled:
@@ -413,6 +416,28 @@ class CPGInfrastructure:
     def deploy_datasets(self):
         for cloud_dataset in self.dataset_infrastructures.values():
             cloud_dataset.main()
+
+    def deploy_adhoc(self):
+        infra = self.common_gcp_infra
+
+        for group in self.config.adhoc_groups or []:
+            cloud_group = self.group_provider.create_group(
+                infra,
+                name=group.name,
+                cache_members=False,
+            )
+            for member_id in group.members:
+                member = self.config.users.get(member_id)
+                if not member:
+                    raise ValueError(f'Member {member_id} not found in config')
+
+                if cloud_user := member.clouds.get(GcpInfrastructure.name()):
+                    pulumi_name = f'{group.name}-{compute_hash("", member_id, GcpInfrastructure.name())}'
+                    cloud_group.add_member(
+                        infra.get_pulumi_name(pulumi_name),
+                        member=cloud_user.id,
+                        user=cloud_user,
+                    )
 
     def setup_hail_batch_billing_project_members(self):
         internal_users = [


### PR DESCRIPTION
Add an `adhoc_groups` field to `CPGInfrastructureConfig` that can be populated to have the driver create miscellaneous google groups that are not associated with datasets.