### PR TITLE
Update infra to support new metamist service

### DIFF
--- a/cpg_infra/config/config.py
+++ b/cpg_infra/config/config.py
@@ -154,6 +154,7 @@ class CPGInfrastructureConfig(DeserializableDataclass):
             project: str
             service_name: str
             machine_account: str
+            legacy_machine_account: str
 
         @dataclasses.dataclass(frozen=True)
         class ETLConfiguration(DeserializableDataclass):

--- a/cpg_infra/driver.py
+++ b/cpg_infra/driver.py
@@ -774,7 +774,7 @@ class CPGInfrastructure:
 
         if self.config.metamist:
             group_cache_accessors.append(
-                ('sample-metadata', self.config.metamist.gcp.machine_account),
+                ('sample-metadata', self.config.metamist.gcp.legacy_machine_account),
             )
 
         if self.config.web_service:
@@ -2588,6 +2588,11 @@ class CPGDatasetCloudInfrastructure:
         self.main_list_group.add_member(
             self.infra.get_pulumi_name('metamist-service-account-in-main-list'),
             self.infra.config.metamist.gcp.machine_account,
+        )
+
+        self.main_list_group.add_member(
+            self.infra.get_pulumi_name('metamist-service-account-in-main-list'),
+            self.infra.config.metamist.gcp.legacy_machine_account,
         )
 
     def setup_metamist_cloudrun_permissions(self):


### PR DESCRIPTION
The only permissions that the metamist service needs to have set by cpg-infrastructure is the ability to list dataset buckets. This is needed for analysis output file validation and statistics. Here we retain access for the legacy service account for the old/existing metamist service, and add permissions for the new metamist service account.

cpg-infrastructure-private PR is here: https://github.com/populationgenomics/cpg-infrastructure-private/pull/671