### PR TITLE
Fix storage visualisation by explicitly installing slack-sdk

### DIFF
--- a/storage_visualization/Dockerfile
+++ b/storage_visualization/Dockerfile
@@ -2,4 +2,5 @@ FROM australia-southeast1-docker.pkg.dev/analysis-runner/images/driver:latest
 
 # Writing an image in plotly requires the kaleido package.
 # 1.0 requires Chrome and a plotly version that's incompatible with Hail.
-RUN pip install 'kaleido<1.0'
+# Also ensure we have the SDK to post to Slack.
+RUN pip install 'kaleido<1.0' slack-sdk


### PR DESCRIPTION
This package was inadvertently dropped from the driver image by populationgenomics/analysis-runner#749, which is [SET-1136](https://cpg-populationanalysis.atlassian.net/browse/SET-1136).

That ticket represents the investigation to recover from that change. In the meantime, this PR gets the storage visualisation working again — as we use slack-sdk we should ensure it is present ourselves.

[SET-1136]: https://cpg-populationanalysis.atlassian.net/browse/SET-1136?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ