### PR TITLE
Enable multiple parallel metamist services (e.g. production and development) in config

### DIFF
--- a/cpg_infra/billing_aggregator/monthly_aggregate/main.py
+++ b/cpg_infra/billing_aggregator/monthly_aggregate/main.py
@@ -128,7 +128,7 @@ async def process_and_upload_monthly_billing_report(
 
     data['cost'].fillna(0)
     data['key'] = data.topic + '-' + data.month + '-' + data.cost_category
-    values: list = data.to_numpy().tolist()
+    values: list = list(data.to_numpy().tolist())
     updated = append_values_to_google_sheet(OUTPUT_GOOGLE_SHEET, values, invoice_month)
 
     return f'{updated} cells appended for invoice month {invoice_month}', 200

--- a/cpg_infra/config/config.py
+++ b/cpg_infra/config/config.py
@@ -318,9 +318,9 @@ class CPGDatasetComponents(Enum):
     ANALYSIS_RUNNER = 'analysis-runner'
 
     @staticmethod
-    def default_component_for_infrastructure() -> dict[
-        str, list['CPGDatasetComponents']
-    ]:
+    def default_component_for_infrastructure() -> (
+        dict[str, list['CPGDatasetComponents']]
+    ):
         return {
             'dry-run': list(CPGDatasetComponents),
             'gcp': list(CPGDatasetComponents),

--- a/cpg_infra/config/config.py
+++ b/cpg_infra/config/config.py
@@ -189,7 +189,7 @@ class CPGInfrastructureConfig(DeserializableDataclass):
             # Custom audience list for the Cloud Run Security
             custom_audience_list: dict[str, list[str]] | None = None
 
-        gcp: GCP
+        gcp: list[GCP]
         etl: ETLConfiguration | None = None
         slack_channel: str | None = None
 
@@ -318,9 +318,9 @@ class CPGDatasetComponents(Enum):
     ANALYSIS_RUNNER = 'analysis-runner'
 
     @staticmethod
-    def default_component_for_infrastructure() -> (
-        dict[str, list['CPGDatasetComponents']]
-    ):
+    def default_component_for_infrastructure() -> dict[
+        str, list['CPGDatasetComponents']
+    ]:
         return {
             'dry-run': list(CPGDatasetComponents),
             'gcp': list(CPGDatasetComponents),

--- a/cpg_infra/driver.py
+++ b/cpg_infra/driver.py
@@ -3,7 +3,6 @@
 CPG Dataset infrastructure
 """
 
-import graphlib
 import json
 import os.path
 import re
@@ -12,6 +11,7 @@ from dataclasses import asdict
 from functools import cached_property
 from typing import Any, Callable, Iterable, Iterator, NamedTuple, Type
 
+import graphlib
 import pulumi
 import pulumi_gcp as gcp
 import toml

--- a/cpg_infra/driver.py
+++ b/cpg_infra/driver.py
@@ -3,6 +3,7 @@
 CPG Dataset infrastructure
 """
 
+import graphlib
 import json
 import os.path
 import re
@@ -11,7 +12,6 @@ from dataclasses import asdict
 from functools import cached_property
 from typing import Any, Callable, Iterable, Iterator, NamedTuple, Type
 
-import graphlib
 import pulumi
 import pulumi_gcp as gcp
 import toml
@@ -798,9 +798,10 @@ class CPGInfrastructure:
             )
 
         if self.config.metamist:
-            group_cache_accessors.append(
-                ('sample-metadata', self.config.metamist.gcp.legacy_machine_account),
-            )
+            for service in self.config.metamist.gcp:
+                group_cache_accessors.append(
+                    (service.service_name, service.machine_account),
+                )
 
         if self.config.web_service:
             group_cache_accessors.append(
@@ -866,12 +867,13 @@ class CPGInfrastructure:
 
         assert self.config.metamist
 
-        infra.add_cloudrun_invoker(
-            'sample-metadata-cloudrun-invokers',
-            service=self.config.metamist.gcp.service_name,
-            project=self.config.metamist.gcp.project,
-            member=self.gcp_metamist_invoker_group,
-        )
+        for service in self.config.metamist.gcp:
+            infra.add_cloudrun_invoker(
+                f'sample-metadata-cloudrun-invokers-{service.service_name}',
+                service=service.service_name,
+                project=service.project,
+                member=self.gcp_metamist_invoker_group,
+            )
 
     @cached_property
     def gcp_python_registry(self):
@@ -2631,15 +2633,11 @@ class CPGDatasetCloudInfrastructure:
         # add metamist machine account to the `main-list` group for the dataset.
         # this group gives list access to the dataset buckets but grants no ability
         # to read the actual contents of objects
-        self.main_list_group.add_member(
-            self.infra.get_pulumi_name('metamist-service-account-in-main-list'),
-            self.infra.config.metamist.gcp.machine_account,
-        )
-
-        self.main_list_group.add_member(
-            self.infra.get_pulumi_name('metamist-service-account-in-main-list'),
-            self.infra.config.metamist.gcp.legacy_machine_account,
-        )
+        for service in self.infra.config.metamist.gcp:
+            self.main_list_group.add_member(
+                self.infra.get_pulumi_name('metamist-service-account-in-main-list'),
+                service.machine_account,
+            )
 
     def setup_metamist_cloudrun_permissions(self):
         # now we give the metamist_access_group access to cloud-run instance


### PR DESCRIPTION
Currently we can only support the permissions and service account access for a single deployment of metamist.

While it is normative that we only have one, during the process of the metamist postgres migration it became clear we needed to support two parallel deployments. 

These permissions that will be deployed by pulumi will allow our current hail accounts and users with their appropriate permissions to access the metamist-development service in the metamist-dev project.

Removing the extra service in config in future should revoke these permissions.

Why do this change at all with Dan's modification for the legacy account? Truly the only critical change was having the `infra.add_cloudrun_invoker` for both the new and legacy accounts. But that call needs not only the machine account but the servcie name and the project name, requiring a refactor.

The justification for the change to a list means that in future we only need to modify the cpg-infrastructure-private config file to remove and add any number of metamist services. The driver will not need to be modified.

Corresponding PR in cpg-infrastructure-private: https://github.com/populationgenomics/cpg-infrastructure-private/pull/695