### PR TITLE
Pip audit - upgrade pytest version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ pulumi-azuread==5.46.0
 pulumi-gcp~=7.6
 pulumi-github>=6.0.0
 pulumi==3.96.2
-pytest==8.3.2
+pytest==9.0.3
 toml-sort
 toml==0.10.2
 xxhash==3.2.0


### PR DESCRIPTION
Name | Version | ID | Fix Versions | Description
--- | --- | --- | --- | ---
pytest | 8.3.2 | CVE-2025-71176 | 9.0.3 | pytest through 9.0.2 on UNIX relies on directories with the `/tmp/pytest-of-{user}` name pattern, which allows local users to cause a denial of service or possibly gain privileges.

Found 1 known vulnerability in 1 package