### PR TITLE
Keep exiting key structure to maintain functionality of metamist etl plugin

### DIFF
--- a/cpg_infra/config/config.py
+++ b/cpg_infra/config/config.py
@@ -160,9 +160,24 @@ class CPGInfrastructureConfig(DeserializableDataclass):
     class Metamist(DeserializableDataclass):
         @dataclasses.dataclass(frozen=True)
         class GCP(DeserializableDataclass):
+            @dataclasses.dataclass(frozen=True)
+            class GCPMetamistDeploys(DeserializableDataclass):
+                project: str
+                service_name: str
+                machine_account: str
+
+            # Weird structure explained:
+            # The project service_name and machine account are left as-is
+            # so the metamist etl infrastructure code defined in the metamist
+            # repo still work. Any additional deploys go into the dev list
+
+            # This way all of the infra.metamist.gcp.project references in the
+            # etl plugin will continue to work
             project: str
             service_name: str
             machine_account: str
+
+            dev: list[GCPMetamistDeploys] | None = None
 
         @dataclasses.dataclass(frozen=True)
         class ETLConfiguration(DeserializableDataclass):
@@ -188,7 +203,14 @@ class CPGInfrastructureConfig(DeserializableDataclass):
             # Custom audience list for the Cloud Run Security
             custom_audience_list: dict[str, list[str]] | None = None
 
-        gcp: list[GCP]
+        def all_gcp_deploys(self) -> list[GCP]:
+            if not self.gcp.dev:
+                return [self.gcp]
+
+            dev_deploys = [self.GCP(**dev.__dict__) for dev in self.gcp.dev]
+            return [self.gcp, *dev_deploys]
+
+        gcp: GCP
         etl: ETLConfiguration | None = None
         slack_channel: str | None = None
 

--- a/cpg_infra/driver.py
+++ b/cpg_infra/driver.py
@@ -798,7 +798,7 @@ class CPGInfrastructure:
             )
 
         if self.config.metamist:
-            for service in self.config.metamist.gcp:
+            for service in self.config.metamist.all_gcp_deploys():
                 group_cache_accessors.append(
                     (service.service_name, service.machine_account),
                 )
@@ -867,7 +867,7 @@ class CPGInfrastructure:
 
         assert self.config.metamist
 
-        for service in self.config.metamist.gcp:
+        for service in self.config.metamist.all_gcp_deploys():
             infra.add_cloudrun_invoker(
                 f'sample-metadata-cloudrun-invokers-{service.service_name}',
                 service=service.service_name,
@@ -2633,7 +2633,8 @@ class CPGDatasetCloudInfrastructure:
         # add metamist machine account to the `main-list` group for the dataset.
         # this group gives list access to the dataset buckets but grants no ability
         # to read the actual contents of objects
-        for service in self.infra.config.metamist.gcp:
+        assert self.infra.config.metamist
+        for service in self.infra.config.metamist.all_gcp_deploys():
             self.main_list_group.add_member(
                 self.infra.get_pulumi_name(
                     f'{service.service_name}-service-account-in-main-list'


### PR DESCRIPTION
Turns out that the metamist etl plugin into infra requires the current config structure. Here's a refactor to keep the existing keys in place so the plugin remains functional.

See plugin in the [metamist repo](https://github.com/populationgenomics/metamist/tree/dev/metamist_infrastructure)