### PR TITLE
Revert to 9f4d0cc (#358): roll back metamist parallel-services changes

### DIFF
--- a/cpg_infra/billing_aggregator/monthly_aggregate/main.py
+++ b/cpg_infra/billing_aggregator/monthly_aggregate/main.py
@@ -128,7 +128,7 @@ async def process_and_upload_monthly_billing_report(
 
     data['cost'].fillna(0)
     data['key'] = data.topic + '-' + data.month + '-' + data.cost_category
-    values: list = list(data.to_numpy().tolist())
+    values: list = data.to_numpy().tolist()
     updated = append_values_to_google_sheet(OUTPUT_GOOGLE_SHEET, values, invoice_month)
 
     return f'{updated} cells appended for invoice month {invoice_month}', 200

--- a/cpg_infra/config/config.py
+++ b/cpg_infra/config/config.py
@@ -160,24 +160,10 @@ class CPGInfrastructureConfig(DeserializableDataclass):
     class Metamist(DeserializableDataclass):
         @dataclasses.dataclass(frozen=True)
         class GCP(DeserializableDataclass):
-            @dataclasses.dataclass(frozen=True)
-            class GCPMetamistDeploys(DeserializableDataclass):
-                project: str
-                service_name: str
-                machine_account: str
-
-            # Weird structure explained:
-            # The project service_name and machine account are left as-is
-            # so the metamist etl infrastructure code defined in the metamist
-            # repo still work. Any additional deploys go into the dev list
-
-            # This way all of the infra.metamist.gcp.project references in the
-            # etl plugin will continue to work
             project: str
             service_name: str
             machine_account: str
-
-            dev: list[GCPMetamistDeploys] | None = None
+            legacy_machine_account: str
 
         @dataclasses.dataclass(frozen=True)
         class ETLConfiguration(DeserializableDataclass):
@@ -202,13 +188,6 @@ class CPGInfrastructureConfig(DeserializableDataclass):
             private_repo_packages: list[str] | None = None
             # Custom audience list for the Cloud Run Security
             custom_audience_list: dict[str, list[str]] | None = None
-
-        def all_gcp_deploys(self) -> list[GCP]:
-            if not self.gcp.dev:
-                return [self.gcp]
-
-            dev_deploys = [self.GCP(**dev.__dict__) for dev in self.gcp.dev]
-            return [self.gcp, *dev_deploys]
 
         gcp: GCP
         etl: ETLConfiguration | None = None

--- a/cpg_infra/driver.py
+++ b/cpg_infra/driver.py
@@ -798,10 +798,9 @@ class CPGInfrastructure:
             )
 
         if self.config.metamist:
-            for index, service in enumerate(self.config.metamist.all_gcp_deploys()):
-                group_cache_accessors.append(
-                    (f'{service.service_name}-{index}', service.machine_account),
-                )
+            group_cache_accessors.append(
+                ('sample-metadata', self.config.metamist.gcp.legacy_machine_account),
+            )
 
         if self.config.web_service:
             group_cache_accessors.append(
@@ -867,13 +866,12 @@ class CPGInfrastructure:
 
         assert self.config.metamist
 
-        for index, service in enumerate(self.config.metamist.all_gcp_deploys()):
-            infra.add_cloudrun_invoker(
-                f'sample-metadata-cloudrun-invokers-{service.service_name}-{index}',
-                service=service.service_name,
-                project=service.project,
-                member=self.gcp_metamist_invoker_group,
-            )
+        infra.add_cloudrun_invoker(
+            'sample-metadata-cloudrun-invokers',
+            service=self.config.metamist.gcp.service_name,
+            project=self.config.metamist.gcp.project,
+            member=self.gcp_metamist_invoker_group,
+        )
 
     @cached_property
     def gcp_python_registry(self):
@@ -2633,14 +2631,15 @@ class CPGDatasetCloudInfrastructure:
         # add metamist machine account to the `main-list` group for the dataset.
         # this group gives list access to the dataset buckets but grants no ability
         # to read the actual contents of objects
-        assert self.infra.config.metamist
-        for index, service in enumerate(self.infra.config.metamist.all_gcp_deploys()):
-            self.main_list_group.add_member(
-                self.infra.get_pulumi_name(
-                    f'metamist-service-account-in-main-list-{service.service_name}-{index}',
-                ),
-                service.machine_account,
-            )
+        self.main_list_group.add_member(
+            self.infra.get_pulumi_name('metamist-service-account-in-main-list'),
+            self.infra.config.metamist.gcp.machine_account,
+        )
+
+        self.main_list_group.add_member(
+            self.infra.get_pulumi_name('metamist-service-account-in-main-list'),
+            self.infra.config.metamist.gcp.legacy_machine_account,
+        )
 
     def setup_metamist_cloudrun_permissions(self):
         # now we give the metamist_access_group access to cloud-run instance

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ pulumi-azuread==5.46.0
 pulumi-gcp~=7.6
 pulumi-github>=6.0.0
 pulumi==3.96.2
-pytest==9.0.3
+pytest==8.3.2
 toml-sort
 toml==0.10.2
 xxhash==3.2.0


### PR DESCRIPTION
## Summary

Rolls back the **7 commits** merged after `9f4d0cc` ("Explicitly install slack-sdk (#358)") to back out a bug introduced in one of those changes while we investigate.

After this PR, the tree on `main` is **identical to commit `9f4d0cc`** (verified: `git diff 9f4d0cc` is empty).

## Reverted commits (newest → oldest)

| Commit | PR | Title |
|--------|-----|-------|
| `7b31de7` | #365 | Add index to enable duplicate service with multiple machine accounts |
| `a7aa6ea` | #364 | Add index to enable duplicate service with multiple machine accounts |
| `94012b8` | #363 | Metamist: Keep existing key structure for etl plugin |
| `01d5ce4` | #362 | Create unique pulumi resource key for each metamist service account |
| `14a027b` | #361 | Remove legacy_machine_account from metamist gcp config |
| `4e33793` | #360 | Pip audit - upgrade pytest version |
| `919093d` | #359 | Enable multiple parallel metamist services |

## Method

History-preserving `git revert` of the full range (`9f4d0cc..HEAD`), squashed into a single revert commit. No force-push, no history rewrite.

## Files affected

- `cpg_infra/billing_aggregator/monthly_aggregate/main.py`
- `cpg_infra/config/config.py`
- `cpg_infra/driver.py`
- `requirements.txt`

## Note

This is a temporary rollback to unblock while the bug is investigated. The reverted changes can be re-applied (e.g. `git revert` of this revert commit) once the bug is identified and fixed.