### PR TITLE
Add metamist infra changes back

### DIFF
--- a/cpg_infra/config/config.py
+++ b/cpg_infra/config/config.py
@@ -160,10 +160,24 @@ class CPGInfrastructureConfig(DeserializableDataclass):
     class Metamist(DeserializableDataclass):
         @dataclasses.dataclass(frozen=True)
         class GCP(DeserializableDataclass):
+            @dataclasses.dataclass(frozen=True)
+            class GCPMetamistDeploys(DeserializableDataclass):
+                project: str
+                service_name: str
+                machine_account: str
+
+            # Weird structure explained:
+            # The project service_name and machine account are left as-is
+            # so the metamist etl infrastructure code defined in the metamist
+            # repo still work. Any additional deploys go into the dev list
+
+            # This way all of the infra.metamist.gcp.project references in the
+            # etl plugin will continue to work
             project: str
             service_name: str
             machine_account: str
-            legacy_machine_account: str
+
+            dev: list[GCPMetamistDeploys] | None = None
 
         @dataclasses.dataclass(frozen=True)
         class ETLConfiguration(DeserializableDataclass):
@@ -188,6 +202,13 @@ class CPGInfrastructureConfig(DeserializableDataclass):
             private_repo_packages: list[str] | None = None
             # Custom audience list for the Cloud Run Security
             custom_audience_list: dict[str, list[str]] | None = None
+
+        def all_gcp_deploys(self) -> list[GCP]:
+            if not self.gcp.dev:
+                return [self.gcp]
+
+            dev_deploys = [self.GCP(**dev.__dict__) for dev in self.gcp.dev]
+            return [self.gcp, *dev_deploys]
 
         gcp: GCP
         etl: ETLConfiguration | None = None

--- a/cpg_infra/config/config.py
+++ b/cpg_infra/config/config.py
@@ -175,9 +175,10 @@ class CPGInfrastructureConfig(DeserializableDataclass):
             # etl plugin will continue to work
             project: str
             service_name: str
-            machine_account: str
+            legacy_machine_account: str
 
-            dev: list[GCPMetamistDeploys] | None = None
+            dev: GCPMetamistDeploys | None = None
+            prod: GCPMetamistDeploys | None = None
 
         @dataclasses.dataclass(frozen=True)
         class ETLConfiguration(DeserializableDataclass):
@@ -202,13 +203,6 @@ class CPGInfrastructureConfig(DeserializableDataclass):
             private_repo_packages: list[str] | None = None
             # Custom audience list for the Cloud Run Security
             custom_audience_list: dict[str, list[str]] | None = None
-
-        def all_gcp_deploys(self) -> list[GCP]:
-            if not self.gcp.dev:
-                return [self.gcp]
-
-            dev_deploys = [self.GCP(**dev.__dict__) for dev in self.gcp.dev]
-            return [self.gcp, *dev_deploys]
 
         gcp: GCP
         etl: ETLConfiguration | None = None

--- a/cpg_infra/config/config.py
+++ b/cpg_infra/config/config.py
@@ -161,7 +161,7 @@ class CPGInfrastructureConfig(DeserializableDataclass):
         @dataclasses.dataclass(frozen=True)
         class GCP(DeserializableDataclass):
             @dataclasses.dataclass(frozen=True)
-            class GCPMetamistDeploys(DeserializableDataclass):
+            class GCPMetamistDeploy(DeserializableDataclass):
                 project: str
                 service_name: str
                 machine_account: str
@@ -177,8 +177,8 @@ class CPGInfrastructureConfig(DeserializableDataclass):
             service_name: str
             legacy_machine_account: str
 
-            dev: GCPMetamistDeploys | None = None
-            prod: GCPMetamistDeploys | None = None
+            dev: GCPMetamistDeploy | None = None
+            prod: GCPMetamistDeploy | None = None
 
         @dataclasses.dataclass(frozen=True)
         class ETLConfiguration(DeserializableDataclass):

--- a/cpg_infra/driver.py
+++ b/cpg_infra/driver.py
@@ -798,9 +798,10 @@ class CPGInfrastructure:
             )
 
         if self.config.metamist:
-            group_cache_accessors.append(
-                ('sample-metadata', self.config.metamist.gcp.legacy_machine_account),
-            )
+            for index, service in enumerate(self.config.metamist.all_gcp_deploys()):
+                group_cache_accessors.append(
+                    (f'{service.service_name}-{index}', service.machine_account),
+                )
 
         if self.config.web_service:
             group_cache_accessors.append(
@@ -866,12 +867,13 @@ class CPGInfrastructure:
 
         assert self.config.metamist
 
-        infra.add_cloudrun_invoker(
-            'sample-metadata-cloudrun-invokers',
-            service=self.config.metamist.gcp.service_name,
-            project=self.config.metamist.gcp.project,
-            member=self.gcp_metamist_invoker_group,
-        )
+        for index, service in enumerate(self.config.metamist.all_gcp_deploys()):
+            infra.add_cloudrun_invoker(
+                f'sample-metadata-cloudrun-invokers-{service.service_name}-{index}',
+                service=service.service_name,
+                project=service.project,
+                member=self.gcp_metamist_invoker_group,
+            )
 
     @cached_property
     def gcp_python_registry(self):
@@ -2631,15 +2633,14 @@ class CPGDatasetCloudInfrastructure:
         # add metamist machine account to the `main-list` group for the dataset.
         # this group gives list access to the dataset buckets but grants no ability
         # to read the actual contents of objects
-        self.main_list_group.add_member(
-            self.infra.get_pulumi_name('metamist-service-account-in-main-list'),
-            self.infra.config.metamist.gcp.machine_account,
-        )
-
-        self.main_list_group.add_member(
-            self.infra.get_pulumi_name('metamist-service-account-in-main-list'),
-            self.infra.config.metamist.gcp.legacy_machine_account,
-        )
+        assert self.infra.config.metamist
+        for index, service in enumerate(self.infra.config.metamist.all_gcp_deploys()):
+            self.main_list_group.add_member(
+                self.infra.get_pulumi_name(
+                    f'metamist-service-account-in-main-list-{service.service_name}-{index}',
+                ),
+                service.machine_account,
+            )
 
     def setup_metamist_cloudrun_permissions(self):
         # now we give the metamist_access_group access to cloud-run instance

--- a/cpg_infra/driver.py
+++ b/cpg_infra/driver.py
@@ -805,11 +805,17 @@ class CPGInfrastructure:
             )
 
             group_cache_accessors.append(
-                (self.config.metamist.gcp.prod.service_name, self.config.metamist.gcp.prod.machine_account),
+                (
+                    self.config.metamist.gcp.prod.service_name,
+                    self.config.metamist.gcp.prod.machine_account,
+                ),
             )
 
             group_cache_accessors.append(
-                (self.config.metamist.gcp.dev.service_name, self.config.metamist.gcp.dev.machine_account),
+                (
+                    self.config.metamist.gcp.dev.service_name,
+                    self.config.metamist.gcp.dev.machine_account,
+                ),
             )
 
         if self.config.web_service:
@@ -2661,15 +2667,14 @@ class CPGDatasetCloudInfrastructure:
         )
 
         self.main_list_group.add_member(
-            self.infra.get_pulumi_name('metamist-service-account-in-main-list'),
+            self.infra.get_pulumi_name('metamist-prod-service-account-in-main-list'),
             self.infra.config.metamist.gcp.prod.machine_account,
         )
 
         self.main_list_group.add_member(
-            self.infra.get_pulumi_name('metamist-service-account-in-main-list'),
+            self.infra.get_pulumi_name('metamist-dev-service-account-in-main-list'),
             self.infra.config.metamist.gcp.dev.machine_account,
         )
-
 
     def setup_metamist_cloudrun_permissions(self):
         # now we give the metamist_access_group access to cloud-run instance

--- a/cpg_infra/driver.py
+++ b/cpg_infra/driver.py
@@ -800,10 +800,17 @@ class CPGInfrastructure:
             )
 
         if self.config.metamist:
-            for index, service in enumerate(self.config.metamist.all_gcp_deploys()):
-                group_cache_accessors.append(
-                    (f'{service.service_name}-{index}', service.machine_account),
-                )
+            group_cache_accessors.append(
+                ('sample-metadata', self.config.metamist.gcp.legacy_machine_account),
+            )
+
+            group_cache_accessors.append(
+                (self.config.metamist.gcp.prod.service_name, self.config.metamist.gcp.prod.machine_account),
+            )
+
+            group_cache_accessors.append(
+                (self.config.metamist.gcp.dev.service_name, self.config.metamist.gcp.dev.machine_account),
+            )
 
         if self.config.web_service:
             group_cache_accessors.append(
@@ -869,13 +876,26 @@ class CPGInfrastructure:
 
         assert self.config.metamist
 
-        for index, service in enumerate(self.config.metamist.all_gcp_deploys()):
-            infra.add_cloudrun_invoker(
-                f'sample-metadata-cloudrun-invokers-{service.service_name}-{index}',
-                service=service.service_name,
-                project=service.project,
-                member=self.gcp_metamist_invoker_group,
-            )
+        infra.add_cloudrun_invoker(
+            'sample-metadata-cloudrun-invokers',
+            service=self.config.metamist.gcp.service_name,
+            project=self.config.metamist.gcp.project,
+            member=self.gcp_metamist_invoker_group,
+        )
+
+        infra.add_cloudrun_invoker(
+            'metamist-cloudrun-invokers',
+            service=self.config.metamist.gcp.prod.service_name,
+            project=self.config.metamist.gcp.prod.project,
+            member=self.gcp_metamist_invoker_group,
+        )
+
+        infra.add_cloudrun_invoker(
+            'metamist-dev-cloudrun-invokers',
+            service=self.config.metamist.gcp.dev.service_name,
+            project=self.config.metamist.gcp.dev.project,
+            member=self.gcp_metamist_invoker_group,
+        )
 
     @cached_property
     def gcp_python_registry(self):
@@ -2635,14 +2655,21 @@ class CPGDatasetCloudInfrastructure:
         # add metamist machine account to the `main-list` group for the dataset.
         # this group gives list access to the dataset buckets but grants no ability
         # to read the actual contents of objects
-        assert self.infra.config.metamist
-        for index, service in enumerate(self.infra.config.metamist.all_gcp_deploys()):
-            self.main_list_group.add_member(
-                self.infra.get_pulumi_name(
-                    f'metamist-service-account-in-main-list-{service.service_name}-{index}',
-                ),
-                service.machine_account,
-            )
+        self.main_list_group.add_member(
+            self.infra.get_pulumi_name('metamist-service-account-in-main-list'),
+            self.infra.config.metamist.gcp.legacy_machine_account,
+        )
+
+        self.main_list_group.add_member(
+            self.infra.get_pulumi_name('metamist-service-account-in-main-list'),
+            self.infra.config.metamist.gcp.prod.machine_account,
+        )
+
+        self.main_list_group.add_member(
+            self.infra.get_pulumi_name('metamist-service-account-in-main-list'),
+            self.infra.config.metamist.gcp.dev.machine_account,
+        )
+
 
     def setup_metamist_cloudrun_permissions(self):
         # now we give the metamist_access_group access to cloud-run instance

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ pulumi-azuread==5.46.0
 pulumi-gcp~=7.6
 pulumi-github>=6.0.0
 pulumi==3.96.2
-pytest==8.3.2
+pytest==9.0.3
 toml-sort
 toml==0.10.2
 xxhash==3.2.0


### PR DESCRIPTION
This PR revert the changes made in https://github.com/populationgenomics/cpg-infrastructure/pull/367
Pulumi preview - https://github.com/populationgenomics/cpg-infrastructure-private/actions/runs/28628754057/job/84900932794

**Additional info**

Currently we can only support the permissions and service account access for a single deployment of metamist.

While it is normative that we only have one, during the process of the metamist postgres migration it became clear we needed to support two parallel deployments.

These permissions that will be deployed by pulumi will allow our current hail accounts and users with their appropriate permissions to access the metamist-development service in the metamist-dev project.

Removing the old service in config in future should revoke these permissions.

Why do this change at all with Dan's modification for the legacy account? Truly the only critical change was having the infra.add_cloudrun_invoker for both the new and legacy accounts. But that call needs not only the machine account but the servcie name and the project name, requiring a refactor.

Corresponding PR in the cpg-infra-private https://github.com/populationgenomics/cpg-infrastructure-private/pull/701


