### PR TITLE
[SET-957] Ignore initial_group_config changes on Cloud Identity groups

### DIFF
--- a/cpg_infra/abstraction/gcp.py
+++ b/cpg_infra/abstraction/gcp.py
@@ -762,7 +762,13 @@ class GcpInfrastructure(CloudInfraBase):
             group_key=gcp.cloudidentity.GroupGroupKeyArgs(id=mail),
             labels={'cloudidentity.googleapis.com/groups.discussion_forum': ''},
             parent=f'customers/{self.config.gcp.customer_id}',
-            opts=pulumi.resource.ResourceOptions(depends_on=[self._svc_cloudidentity]),
+            opts=pulumi.resource.ResourceOptions(
+                depends_on=[self._svc_cloudidentity],
+                # initial_group_config is create-only and never returned by the
+                # Cloud Identity API, so imported groups always show a phantom
+                # diff that forces a replacement (which fails with 409).
+                ignore_changes=['initial_group_config'],
+            ),
         )
 
         # Only set allowExternalMembers': 'true' if settings specify it


### PR DESCRIPTION
## Problem

Re-enabling adhoc group creation in `cpg-infrastructure-private` fails the production deploy with:

```
++ gcp:cloudidentity:Group common-gcp-hail-dev-group creating replacement [diff: +initialGroupConfig-description]
error: Error 409: Error(2018): Cannot create group 'hail-dev@populationgenomics.org.au' because it already exists.
```

## Root cause

`initial_group_config` is a **create-only, ForceNew** field on `gcp.cloudidentity.Group`, and the Cloud Identity API **never returns it on read**. Groups brought in via `pulumi import` therefore have no value for it in state, while the program always sets `EMPTY`/`WITH_INITIAL_OWNER`. That mismatch shows up as a phantom `+initialGroupConfig` diff on every `pulumi up`, forcing a replacement. The create half of the (create-before-delete) replacement then fails with a 409 because the group already exists.

This is why the `pulumi import` results looked correct but the deploy still failed.

## Fix

Add `ignore_changes=['initial_group_config']` to the group's `ResourceOptions`. The field is only meaningful at creation, so ignoring subsequent diffs is safe for all groups and removes the spurious replacement.

## Follow-up

Unblocks re-enabling adhoc groups in cpg-infrastructure-private (companion PR). This needs to release and be picked up by that repo's `requirements.txt` before the re-enable is deployed.