### PR TITLE
Ignore initial_group_config when comparing groups and populate description

### DIFF
--- a/cpg_infra/abstraction/azure.py
+++ b/cpg_infra/abstraction/azure.py
@@ -440,10 +440,11 @@ class AzureInfra(CloudInfraBase):
     def get_credentials_for_machine_account(self, resource_key, account):
         pass
 
-    def create_group(self, name: str) -> Any:
+    def create_group(self, name: str, description: str | None = None) -> Any:
         return azuread.Group(
             self.get_pulumi_name(name + '-group'),
             display_name=name,
+            description=description,
             security_enabled=True,
         )
 

--- a/cpg_infra/abstraction/base.py
+++ b/cpg_infra/abstraction/base.py
@@ -298,7 +298,7 @@ class CloudInfraBase(ABC):
     # endregion MACHINE ACCOUNTS
     # GROUPS
     @abstractmethod
-    def create_group(self, name: str) -> Any:
+    def create_group(self, name: str, description: str | None = None) -> Any:
         """
         Create a GROUP, which is a proxy for a number of members
         """
@@ -466,8 +466,9 @@ class DryRunInfra(CloudInfraBase):
     def get_credentials_for_machine_account(self, resource_key, account):
         return f'{resource_key} :: {account}.CREDENTIALS'
 
-    def create_group(self, name: str) -> Any:
-        print(f'Creating Group: {name}')
+    def create_group(self, name: str, description: str | None = None) -> Any:
+        desc = f' (description: {description})' if description else ''
+        print(f'Creating Group: {name}{desc}')
         return f'{name}@{self.config.gcp.groups_domain}'
 
     def add_group_member(

--- a/cpg_infra/abstraction/gcp.py
+++ b/cpg_infra/abstraction/gcp.py
@@ -762,7 +762,11 @@ class GcpInfrastructure(CloudInfraBase):
             group_key=gcp.cloudidentity.GroupGroupKeyArgs(id=mail),
             labels={'cloudidentity.googleapis.com/groups.discussion_forum': ''},
             parent=f'customers/{self.config.gcp.customer_id}',
-            opts=pulumi.resource.ResourceOptions(depends_on=[self._svc_cloudidentity]),
+            opts=pulumi.resource.ResourceOptions(
+                depends_on=[self._svc_cloudidentity],
+                # Pre-existing groups may have null instead of EMPTY etc, so ignore this
+                ignore_changes=['initial_group_config'],
+            ),
         )
 
         # Only set allowExternalMembers': 'true' if settings specify it

--- a/cpg_infra/abstraction/gcp.py
+++ b/cpg_infra/abstraction/gcp.py
@@ -746,7 +746,7 @@ class GcpInfrastructure(CloudInfraBase):
             service_account_id=account.email,
         ).private_key.apply(lambda s: base64.b64decode(s).decode('utf-8'))
 
-    def create_group(self, name: str) -> Any:
+    def create_group(self, name: str, description: str | None = None) -> Any:
         mail = f'{name}@{self.config.gcp.groups_domain}'
 
         # Dev GCP accounts don't have access to create empty groups, so on dev they are
@@ -758,6 +758,7 @@ class GcpInfrastructure(CloudInfraBase):
         group = gcp.cloudidentity.Group(
             self.get_pulumi_name(name + '-group'),
             display_name=name,
+            description=description,
             initial_group_config=initial_group_config,
             group_key=gcp.cloudidentity.GroupGroupKeyArgs(id=mail),
             labels={'cloudidentity.googleapis.com/groups.discussion_forum': ''},

--- a/cpg_infra/driver.py
+++ b/cpg_infra/driver.py
@@ -218,6 +218,7 @@ class CPGInfrastructure:
             name: str,
             cache_members: bool,
             members: dict | None = None,
+            description: str | None = None,
         ) -> Group:
             if infra.name() not in self.groups:
                 self.groups[infra.name()] = {}
@@ -228,7 +229,7 @@ class CPGInfrastructure:
                 name=name,
                 cache_members=cache_members,
                 members=members or {},
-                group=infra.create_group(self.group_prefix + name),
+                group=infra.create_group(self.group_prefix + name, description),
             )
             self.groups[infra.name()][name] = group
 
@@ -424,6 +425,7 @@ class CPGInfrastructure:
             cloud_group = self.group_provider.create_group(
                 infra,
                 name=group.name,
+                description=group.description,
                 cache_members=False,
             )
             for member_id in group.members:


### PR DESCRIPTION
As per #369's suggestion, ignoring this field may resolve the problems we've had with modelling pre-existing groups in Pulumi.

Also populate the `gcp.cloudidentity.Group` `description` field from the corresponding field in cpg-infrastructure-private's _groups.yaml_.