### PR TITLE
Re-apply pytest dependency update to silence pip audit

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ pulumi-azuread==5.46.0
 pulumi-gcp~=7.6
 pulumi-github>=6.0.0
 pulumi==3.96.2
-pytest==8.3.2
+pytest==9.1.0
 toml-sort
 toml==0.10.2
 xxhash==3.2.0


### PR DESCRIPTION
Re-apply #360, which was reverted along with other recent changes in #367.

In the meantime, 9.1.0 has been released.