### PR TITLE
Allow adhoc groups to set extra Google Group settings

### DIFF
--- a/cpg_infra/abstraction/azure.py
+++ b/cpg_infra/abstraction/azure.py
@@ -443,6 +443,7 @@ class AzureInfra(CloudInfraBase):
     def create_group(
         self,
         name: str,
+        *,
         description: str | None = None,
         group_settings: dict[str, str] | None = None,
     ) -> Any:

--- a/cpg_infra/abstraction/azure.py
+++ b/cpg_infra/abstraction/azure.py
@@ -440,7 +440,14 @@ class AzureInfra(CloudInfraBase):
     def get_credentials_for_machine_account(self, resource_key, account):
         pass
 
-    def create_group(self, name: str, description: str | None = None) -> Any:
+    def create_group(
+        self,
+        name: str,
+        description: str | None = None,
+        group_settings: dict[str, str] | None = None,
+    ) -> Any:
+        # group_settings are Google Groups Settings keys; Azure AD has no equivalent, so ignore.
+        del group_settings
         return azuread.Group(
             self.get_pulumi_name(name + '-group'),
             display_name=name,

--- a/cpg_infra/abstraction/base.py
+++ b/cpg_infra/abstraction/base.py
@@ -301,6 +301,7 @@ class CloudInfraBase(ABC):
     def create_group(
         self,
         name: str,
+        *,
         description: str | None = None,
         group_settings: dict[str, str] | None = None,
     ) -> Any:
@@ -478,6 +479,7 @@ class DryRunInfra(CloudInfraBase):
     def create_group(
         self,
         name: str,
+        *,
         description: str | None = None,
         group_settings: dict[str, str] | None = None,
     ) -> Any:

--- a/cpg_infra/abstraction/base.py
+++ b/cpg_infra/abstraction/base.py
@@ -298,9 +298,18 @@ class CloudInfraBase(ABC):
     # endregion MACHINE ACCOUNTS
     # GROUPS
     @abstractmethod
-    def create_group(self, name: str, description: str | None = None) -> Any:
+    def create_group(
+        self,
+        name: str,
+        description: str | None = None,
+        group_settings: dict[str, str] | None = None,
+    ) -> Any:
         """
         Create a GROUP, which is a proxy for a number of members
+
+        group_settings: extra provider-specific group settings (GCP: Google Groups
+        Settings API keys, e.g. whoCanPostMessage); ignored by providers without
+        an equivalent.
         """
 
     @abstractmethod
@@ -466,9 +475,15 @@ class DryRunInfra(CloudInfraBase):
     def get_credentials_for_machine_account(self, resource_key, account):
         return f'{resource_key} :: {account}.CREDENTIALS'
 
-    def create_group(self, name: str, description: str | None = None) -> Any:
+    def create_group(
+        self,
+        name: str,
+        description: str | None = None,
+        group_settings: dict[str, str] | None = None,
+    ) -> Any:
         desc = f' (description: {description})' if description else ''
-        print(f'Creating Group: {name}{desc}')
+        settings = f' (settings: {group_settings})' if group_settings else ''
+        print(f'Creating Group: {name}{desc}{settings}')
         return f'{name}@{self.config.gcp.groups_domain}'
 
     def add_group_member(

--- a/cpg_infra/abstraction/gcp.py
+++ b/cpg_infra/abstraction/gcp.py
@@ -776,23 +776,15 @@ class GcpInfrastructure(CloudInfraBase):
             ),
         )
 
-        # Group settings: allowExternalMembers is governed solely by the global
-        # allow_external_group_members flag (dev accounts lack permission to change
-        # it), so it is stripped from any per-group override to avoid re-enabling
-        # what the flag disables. Other keys (e.g. whoCanPostMessage for a
-        # world-postable group) merge in. Only emit the resource when non-empty.
-        settings: dict[str, str] = {
-            k: v
-            for k, v in (group_settings or {}).items()
-            if k != 'allowExternalMembers'
-        }
-        if self.config.gcp.allow_external_group_members:
-            settings['allowExternalMembers'] = 'true'
-        if settings:
+        # Every Google Group setting (allowExternalMembers, whoCanPostMessage, …)
+        # requires Workspace-admin privileges the deploying identity may lack (dev
+        # deploys), so gate the whole resource rather than individual keys: skip it
+        # entirely when this deploy can't set group settings.
+        if self.config.gcp.can_set_group_settings:
             GoogleGroupSettings(
                 self.get_pulumi_name(name + '-group-settings'),
                 group_email=mail,
-                settings=settings,
+                settings={'allowExternalMembers': 'true', **(group_settings or {})},
                 opts=pulumi.resource.ResourceOptions(depends_on=[group]),
             )
         return group

--- a/cpg_infra/abstraction/gcp.py
+++ b/cpg_infra/abstraction/gcp.py
@@ -776,7 +776,7 @@ class GcpInfrastructure(CloudInfraBase):
             ),
         )
 
-        # Every Google Group setting (allowExternalMembers, whoCanPostMessage, …)
+        # Every Google Group setting (allowExternalMembers, whoCanPostMessage, ...)
         # requires Workspace-admin privileges the deploying identity may lack (dev
         # deploys), so gate the whole resource rather than individual keys: skip it
         # entirely when this deploy can't set group settings.

--- a/cpg_infra/abstraction/gcp.py
+++ b/cpg_infra/abstraction/gcp.py
@@ -749,6 +749,7 @@ class GcpInfrastructure(CloudInfraBase):
     def create_group(
         self,
         name: str,
+        *,
         description: str | None = None,
         group_settings: dict[str, str] | None = None,
     ) -> Any:

--- a/cpg_infra/abstraction/gcp.py
+++ b/cpg_infra/abstraction/gcp.py
@@ -776,15 +776,18 @@ class GcpInfrastructure(CloudInfraBase):
             ),
         )
 
-        # Group settings: allowExternalMembers (unless disabled — defaults to True)
-        # plus any per-group overrides (e.g. whoCanPostMessage for a world-postable
-        # group). Only emit the settings resource when there is something to set.
-        settings: dict[str, str] = {}
+        # Group settings: allowExternalMembers is governed solely by the global
+        # allow_external_group_members flag (dev accounts lack permission to change
+        # it), so it is stripped from any per-group override to avoid re-enabling
+        # what the flag disables. Other keys (e.g. whoCanPostMessage for a
+        # world-postable group) merge in. Only emit the resource when non-empty.
+        settings: dict[str, str] = {
+            k: v
+            for k, v in (group_settings or {}).items()
+            if k != 'allowExternalMembers'
+        }
         if self.config.gcp.allow_external_group_members:
-            # Allow domain-external members in the group.
             settings['allowExternalMembers'] = 'true'
-        if group_settings:
-            settings.update(group_settings)
         if settings:
             GoogleGroupSettings(
                 self.get_pulumi_name(name + '-group-settings'),

--- a/cpg_infra/abstraction/gcp.py
+++ b/cpg_infra/abstraction/gcp.py
@@ -746,7 +746,12 @@ class GcpInfrastructure(CloudInfraBase):
             service_account_id=account.email,
         ).private_key.apply(lambda s: base64.b64decode(s).decode('utf-8'))
 
-    def create_group(self, name: str, description: str | None = None) -> Any:
+    def create_group(
+        self,
+        name: str,
+        description: str | None = None,
+        group_settings: dict[str, str] | None = None,
+    ) -> Any:
         mail = f'{name}@{self.config.gcp.groups_domain}'
 
         # Dev GCP accounts don't have access to create empty groups, so on dev they are
@@ -770,14 +775,20 @@ class GcpInfrastructure(CloudInfraBase):
             ),
         )
 
-        # Only set allowExternalMembers': 'true' if settings specify it
-        # this defaults to True
+        # Group settings: allowExternalMembers (unless disabled — defaults to True)
+        # plus any per-group overrides (e.g. whoCanPostMessage for a world-postable
+        # group). Only emit the settings resource when there is something to set.
+        settings: dict[str, str] = {}
         if self.config.gcp.allow_external_group_members:
             # Allow domain-external members in the group.
+            settings['allowExternalMembers'] = 'true'
+        if group_settings:
+            settings.update(group_settings)
+        if settings:
             GoogleGroupSettings(
                 self.get_pulumi_name(name + '-group-settings'),
                 group_email=mail,
-                settings={'allowExternalMembers': 'true'},
+                settings=settings,
                 opts=pulumi.resource.ResourceOptions(depends_on=[group]),
             )
         return group

--- a/cpg_infra/abstraction/google_group_settings.py
+++ b/cpg_infra/abstraction/google_group_settings.py
@@ -76,10 +76,11 @@ class GoogleGroupSettings(pulumi.dynamic.Resource):
     """A Pulumi dynamic resource for Google Groups settings."""
 
     group_email: pulumi.Output[str]
-    # Allowed keys are documented (partially) by GoogleGroupSettingsDict above;
-    # full reference:
+    # Holds any Google Groups Settings API key (so typed as a plain dict, not the
+    # partial GoogleGroupSettingsDict); the common/known keys are documented by
+    # GoogleGroupSettingsDict above. Full reference:
     # https://developers.google.com/admin-sdk/groups-settings/v1/reference/groups
-    settings: pulumi.Output[GoogleGroupSettingsDict]
+    settings: pulumi.Output[dict]
 
     def __init__(
         self,

--- a/cpg_infra/abstraction/google_group_settings.py
+++ b/cpg_infra/abstraction/google_group_settings.py
@@ -20,7 +20,7 @@ class GoogleGroupSettingsDict(TypedDict, total=False):
     """Documented (partial, non-exhaustive) Google Groups Settings API keys.
 
     The keys cpg_infra sets or is likely to. `total=False`: every key is
-    optional. The `Literal` value sets are the API's enums as of writing — see
+    optional. The `Literal` value sets are the API's enums as of writing -- see
     the authoritative reference for the full/updated key and value lists:
     https://developers.google.com/admin-sdk/groups-settings/v1/reference/groups
     """

--- a/cpg_infra/abstraction/google_group_settings.py
+++ b/cpg_infra/abstraction/google_group_settings.py
@@ -4,6 +4,7 @@ Contains pulumi.dynamic.ResourceProvider implementations for Google Groups setti
 """
 
 from functools import cache
+from typing import Literal, TypedDict
 
 import google.auth
 import googleapiclient.discovery
@@ -11,14 +12,74 @@ import pulumi
 import pulumi.dynamic
 from google.auth.transport.requests import Request
 
+# API enums use 'true'/'false' strings, not Python bools.
+_BoolStr = Literal['true', 'false']
+
+
+class GoogleGroupSettingsDict(TypedDict, total=False):
+    """Documented (partial, non-exhaustive) Google Groups Settings API keys.
+
+    The keys cpg_infra sets or is likely to. `total=False`: every key is
+    optional. The `Literal` value sets are the API's enums as of writing — see
+    the authoritative reference for the full/updated key and value lists:
+    https://developers.google.com/admin-sdk/groups-settings/v1/reference/groups
+    """
+
+    allowExternalMembers: _BoolStr
+    whoCanPostMessage: Literal[
+        'NONE_CAN_POST',
+        'ALL_MANAGERS_CAN_POST',
+        'ALL_OWNERS_CAN_POST',
+        'ALL_MEMBERS_CAN_POST',
+        'ALL_IN_DOMAIN_CAN_POST',
+        'ANYONE_CAN_POST',  # world-postable
+    ]
+    whoCanJoin: Literal[
+        'ANYONE_CAN_JOIN',
+        'ALL_IN_DOMAIN_CAN_JOIN',
+        'INVITED_CAN_JOIN',
+        'CAN_REQUEST_TO_JOIN',
+    ]
+    whoCanViewGroup: Literal[
+        'ANYONE_CAN_VIEW',
+        'ALL_IN_DOMAIN_CAN_VIEW',
+        'ALL_MEMBERS_CAN_VIEW',
+        'ALL_MANAGERS_CAN_VIEW',
+        'ALL_OWNERS_CAN_VIEW',
+    ]
+    whoCanViewMembership: Literal[
+        'ALL_IN_DOMAIN_CAN_VIEW',
+        'ALL_MEMBERS_CAN_VIEW',
+        'ALL_MANAGERS_CAN_VIEW',
+        'ALL_OWNERS_CAN_VIEW',
+    ]
+    messageModerationLevel: Literal[
+        'MODERATE_ALL_MESSAGES',
+        'MODERATE_NON_MEMBERS',
+        'MODERATE_NEW_MEMBERS',
+        'MODERATE_NONE',
+    ]
+    spamModerationLevel: Literal['ALLOW', 'MODERATE', 'SILENTLY_MODERATE', 'REJECT']
+    replyTo: Literal[
+        'REPLY_TO_CUSTOM',
+        'REPLY_TO_SENDER',
+        'REPLY_TO_LIST',
+        'REPLY_TO_OWNER',
+        'REPLY_TO_IGNORE',
+        'REPLY_TO_MANAGERS',
+    ]
+    archiveOnly: _BoolStr
+    membersCanPostAsTheGroup: _BoolStr
+
 
 class GoogleGroupSettings(pulumi.dynamic.Resource):
     """A Pulumi dynamic resource for Google Groups settings."""
 
     group_email: pulumi.Output[str]
-    # See https://developers.google.com/admin-sdk/groups-settings/v1/reference/groups
-    # for the possible settings.
-    settings: pulumi.Output[dict]
+    # Allowed keys are documented (partially) by GoogleGroupSettingsDict above;
+    # full reference:
+    # https://developers.google.com/admin-sdk/groups-settings/v1/reference/groups
+    settings: pulumi.Output[GoogleGroupSettingsDict]
 
     def __init__(
         self,

--- a/cpg_infra/config/config.py
+++ b/cpg_infra/config/config.py
@@ -73,11 +73,12 @@ class CPGInfrastructureConfig(DeserializableDataclass):
         budget_notification_pubsub: str | None
         config_bucket_name: str
         dataset_storage_prefix: str
-        # This is mostly just to allow dev deploys to work, changing the setting to allow
-        # external members on a group requires a high level of access permissions which
-        # we don't want to give to all developers. Setting this to false will stop the
-        # infra code from trying to change that setting
-        allow_external_group_members: bool = True
+        # Whether this deploy may set Google Group settings (allowExternalMembers,
+        # whoCanPostMessage, …). All of them require Workspace-admin privileges most
+        # developers lack, so dev deploys set this False to skip the group-settings
+        # resource entirely and avoid permission-denied failures. (A sibling of
+        # create_empty_groups, which gates a separate group-creation privilege.)
+        can_set_group_settings: bool = True
         # Creating groups without an initial member requires extra access permissions
         # so allow this to be turned off to make dev deploys possible
         create_empty_groups: bool = True

--- a/cpg_infra/config/config.py
+++ b/cpg_infra/config/config.py
@@ -48,7 +48,9 @@ class CPGInfrastructureGroup(DeserializableDataclass):
     members: list[MemberKey] = dataclasses.field(default_factory=list)
     # Extra Google Groups Settings API keys merged into the group's settings,
     # e.g. {'whoCanPostMessage': 'ANYONE_CAN_POST'} to make a group world-postable.
-    # See https://developers.google.com/admin-sdk/groups-settings/v1/reference/groups
+    # Allowed keys are documented by GoogleGroupSettingsDict
+    # (cpg_infra.abstraction.google_group_settings); kept as a plain dict here so
+    # the config deserializer handles it (TypedDicts break its isinstance check).
     group_settings: dict[str, str] = dataclasses.field(default_factory=dict)
 
 

--- a/cpg_infra/config/config.py
+++ b/cpg_infra/config/config.py
@@ -46,6 +46,10 @@ class CPGInfrastructureGroup(DeserializableDataclass):
     name: str
     description: str
     members: list[MemberKey] = dataclasses.field(default_factory=list)
+    # Extra Google Groups Settings API keys merged into the group's settings,
+    # e.g. {'whoCanPostMessage': 'ANYONE_CAN_POST'} to make a group world-postable.
+    # See https://developers.google.com/admin-sdk/groups-settings/v1/reference/groups
+    group_settings: dict[str, str] = dataclasses.field(default_factory=dict)
 
 
 @dataclasses.dataclass(frozen=True)

--- a/cpg_infra/config/config.py
+++ b/cpg_infra/config/config.py
@@ -74,7 +74,7 @@ class CPGInfrastructureConfig(DeserializableDataclass):
         config_bucket_name: str
         dataset_storage_prefix: str
         # Whether this deploy may set Google Group settings (allowExternalMembers,
-        # whoCanPostMessage, …). All of them require Workspace-admin privileges most
+        # whoCanPostMessage, ...). All of them require Workspace-admin privileges most
         # developers lack, so dev deploys set this False to skip the group-settings
         # resource entirely and avoid permission-denied failures. (A sibling of
         # create_empty_groups, which gates a separate group-creation privilege.)

--- a/cpg_infra/driver.py
+++ b/cpg_infra/driver.py
@@ -219,6 +219,7 @@ class CPGInfrastructure:
             cache_members: bool,
             members: dict | None = None,
             description: str | None = None,
+            group_settings: dict[str, str] | None = None,
         ) -> Group:
             if infra.name() not in self.groups:
                 self.groups[infra.name()] = {}
@@ -229,7 +230,9 @@ class CPGInfrastructure:
                 name=name,
                 cache_members=cache_members,
                 members=members or {},
-                group=infra.create_group(self.group_prefix + name, description),
+                group=infra.create_group(
+                    self.group_prefix + name, description, group_settings
+                ),
             )
             self.groups[infra.name()][name] = group
 
@@ -427,6 +430,7 @@ class CPGInfrastructure:
                 name=group.name,
                 description=group.description,
                 cache_members=False,
+                group_settings=group.group_settings,
             )
             for member_id in group.members:
                 member = self.config.users.get(member_id)

--- a/cpg_infra/driver.py
+++ b/cpg_infra/driver.py
@@ -217,6 +217,7 @@ class CPGInfrastructure:
             infra: CloudInfraBase,
             name: str,
             cache_members: bool,
+            *,
             members: dict | None = None,
             description: str | None = None,
             group_settings: dict[str, str] | None = None,
@@ -231,7 +232,9 @@ class CPGInfrastructure:
                 cache_members=cache_members,
                 members=members or {},
                 group=infra.create_group(
-                    self.group_prefix + name, description, group_settings
+                    self.group_prefix + name,
+                    description=description,
+                    group_settings=group_settings,
                 ),
             )
             self.groups[infra.name()][name] = group
@@ -1086,7 +1089,7 @@ class CPGDatasetCloudInfrastructure:
         # outputs
         self.storage_tomls: dict = {}
 
-    def create_group(self, name: str, cache_members: bool = False):
+    def create_group(self, name: str, *, cache_members: bool = False):
         """
         Create a group with the dataset name as a prefix.
 


### PR DESCRIPTION
Adds an optional `group_settings: dict[str, str]` to `CPGInfrastructureGroup`, merged into the group's Google Groups Settings, so a group can declare e.g. `whoCanPostMessage: ANYONE_CAN_POST` ("world-postable").

### Why
A group's address is being registered for third-party API access, so external senders must be able to post to it. There was no way to set posting permissions; the only group setting wired was `allowExternalMembers`.

### What
- `CPGInfrastructureGroup` gains `group_settings` (default empty). Common keys/values are documented by a `GoogleGroupSettingsDict` TypedDict (documentation only — the field stays `dict[str, str]`; the config deserializer does `isinstance()` on field types and TypedDicts raise on `isinstance`).
- Threaded through `CloudInfraBase.create_group` and the adhoc-group deploy path. Azure has no equivalent and ignores it.
- **All Google Group settings are gated as one unit.** Every setting (`allowExternalMembers`, `whoCanPostMessage`, …) needs Workspace-admin privileges the deploying identity may lack on dev deploys, so the whole `GoogleGroupSettings` resource is skipped when the deploy can't set them — guarding only `allowExternalMembers` wasn't enough once arbitrary keys could be set. The flag is renamed to reflect this: `allow_external_group_members` → **`can_set_group_settings`** (kept separate from `create_empty_groups`, which gates a distinct group-creation privilege).

### Compatibility
- **The `group_settings` field is additive** (groups without it are unchanged).
- **Config flag renamed:** `allow_external_group_members` → `can_set_group_settings` (same default `True`, same direction). Not set in committed prod config, so prod is unaffected; **dev configs that set the old key must rename it** (the config deserializer rejects unknown keys, so it fails loud). `docs/development.md` in cpg-infrastructure-private updated (populationgenomics/cpg-infrastructure-private#723).
- **Signature change (deliberate):** defaulted `create_group` args are now **keyword-only**. Backward-incompatible for callers passing `description`/`members`/`cache_members` positionally; all in-tree callers updated.

Consumed by cpg-infrastructure-private#723 (themis-dev → world-postable). Mechanism here; policy (which keys) in `groups.yaml`.