### PR TITLE
Use modern (>=Py3.10) importlib.metadata.entry_points() style

### DIFF
--- a/cpg_infra/plugin/__init__.py
+++ b/cpg_infra/plugin/__init__.py
@@ -34,9 +34,7 @@ def get_plugins() -> dict[str, type[CpgInfrastructurePlugin]]:
 
     plugins = {}
 
-    for entry_point in importlib.metadata.entry_points().get(
-        PLUGIN_ENTRYPOINT_NAME, []
-    ):
+    for entry_point in importlib.metadata.entry_points(group=PLUGIN_ENTRYPOINT_NAME):
         plugins[entry_point.name] = entry_point.load()
 
     return plugins


### PR DESCRIPTION
The `entry_points().get()` functionality has been [removed as of Python 3.12](https://docs.python.org/3/library/importlib.metadata.html#importlib.metadata.EntryPoint). This modernises the code to use the new-style syntax which is usable since Python 3.10. (cpg-infrastructure doesn't really declare a Python version baseline, but `from types import UnionType` and the `foo | bar` type annotations make the code 3.10+ only and the actions all execute this code with 3.11.)

The `importlib.metadata.entry_points(…)` functionality is under-documented, but we can demonstrate that this code works similarly to the old code under e.g. 3.11:

```
>>> importlib.metadata.entry_points().get('cpginfra.plugins')
[EntryPoint(name='billing_aggregator', value='cpg_infra.billing_aggregator.driver:BillingAggregator', group='cpginfra.plugins')]

>>> importlib.metadata.entry_points(group='cpginfra.plugins')
[EntryPoint(name='billing_aggregator', value='cpg_infra.billing_aggregator.driver:BillingAggregator', group='cpginfra.plugins')]
```

and that we don't need an explicit `[]` fall-back anymore:

```
>>> importlib.metadata.entry_points(group='unknown')
[]
```