### PR TITLE
Refactor config type deserializer into match/case dispatch

### DIFF
--- a/cpg_infra/config/deserializabledataclass.py
+++ b/cpg_infra/config/deserializabledataclass.py
@@ -195,8 +195,9 @@ def try_parse_value_as_type(value: Any, dtype: Any) -> Any:
 
     # Otherwise dtype resolves to a concrete class: the generic's origin
     # (`list[str]` -> list) or the bare type itself (dict, a TypedDict, a
-    # DeserializableDataclass, int, ...).
-    cls = origin or dtype
+    # DeserializableDataclass, int, ...). Typed Any: origin/dtype are dynamic
+    # type objects that the isclass guard below narrows at runtime.
+    cls: Any = origin or dtype
 
     # Parameterised/bare containers, with element coercion.
     if parser := CONTAINER_PARSERS.get(cls):
@@ -213,7 +214,7 @@ def try_parse_value_as_type(value: Any, dtype: Any) -> Any:
         match value:
             case dict():
                 return cls.instantiate(**value)
-            case cls():  # already deserialised -- pass through
+            case _ if isinstance(value, cls):  # already deserialised -- pass through
                 return value
             case _:
                 raise ValueError(f'Expected dict, got {type(value)} for {value!r}')

--- a/cpg_infra/config/deserializabledataclass.py
+++ b/cpg_infra/config/deserializabledataclass.py
@@ -5,9 +5,11 @@ with some extra functionality for parsing types.
 """
 
 import dataclasses
+import types
+import typing
+from collections.abc import Callable
 from inspect import isclass
-from types import UnionType
-from typing import Any, Literal, get_args, get_origin
+from typing import Any, Final, get_args, get_origin
 
 
 @dataclasses.dataclass(frozen=True)
@@ -60,11 +62,106 @@ def get_display_type(t: Any):
     if isclass(t):
         return t.__name__
     if isinstance(t, tuple):
-        return ' | '.join(get_display_type(t) for t in t) + ']'
-    if isinstance(t, UnionType):
+        return ' | '.join(get_display_type(x) for x in t)
+    if isinstance(t, types.UnionType):
         return ' | '.join(get_display_type(t) for t in get_args(t))
 
     return repr(t)
+
+
+PRIMITIVES: Final[tuple[type, ...]] = (str, int, bool, float, bytes)
+
+
+def _parse_list(value: Any, args: tuple) -> Any:
+    if not isinstance(value, list):
+        raise ValueError(
+            f'Expected list, got {get_display_type_from_value(value)} for {value!r}',
+        )
+    if len(args) != 1:
+        # list[any]
+        return value
+    return [try_parse_value_as_type(v, args[0]) for v in value]
+
+
+def _parse_set(value: Any, args: tuple) -> Any:
+    if not isinstance(value, (set, list)):
+        raise ValueError(
+            f'Expected set, got {get_display_type_from_value(value)} for {value!r}',
+        )
+    if len(args) != 1:
+        # set[any]
+        return set(value)
+    return {try_parse_value_as_type(v, args[0]) for v in value}
+
+
+def _parse_dict(value: Any, args: tuple) -> Any:
+    if not isinstance(value, dict):
+        raise ValueError(
+            f'Expected dict, got {get_display_type_from_value(value)} for {value!r}',
+        )
+    if len(args) != 2:
+        # dict[any, any] -- no casting of keys or values
+        return value
+    return {k: try_parse_value_as_type(v, args[1]) for k, v in value.items()}
+
+
+def _parse_tuple(value: Any, args: tuple) -> Any:
+    if not isinstance(value, (tuple, list)):
+        raise ValueError(
+            f'Expected tuple, got {get_display_type_from_value(value)} for {value!r}',
+        )
+    if len(args) == 0:
+        # bare tuple -- no element types
+        return tuple(value)
+    if len(args) == 2 and args[1] is Ellipsis:
+        # tuple[X, ...] -- variable-length, homogeneous
+        return tuple(try_parse_value_as_type(v, args[0]) for v in value)
+    if len(args) != len(value):
+        raise ValueError(
+            f'Expected tuple of length {len(args)}, got {len(value)} for {value!r}',
+        )
+    return tuple(try_parse_value_as_type(v, t) for v, t in zip(value, args))
+
+
+# Dispatch table keyed by a type's origin (get_origin(list[str]) is list), which
+# also matches the bare builtin (get_origin(list) is None, so we fall back to
+# dtype itself).
+CONTAINER_PARSERS: Final[dict[type, Callable[[Any, tuple], Any]]] = {
+    list: _parse_list,
+    set: _parse_set,
+    dict: _parse_dict,
+    tuple: _parse_tuple,
+}
+
+
+def _is_none_type(t: Any) -> bool:
+    """True if t denotes NoneType as a union member (bare None or NoneType)."""
+    return t is None or t is type(None)
+
+
+def _parse_union(value: Any, args: tuple) -> Any:
+    if value is None:
+        if any(_is_none_type(t) for t in args):
+            return None
+        raise ValueError(
+            f'Expected (non-optional) {get_display_type(args)}, got None',
+        )
+
+    # value is non-None here, so the NoneType branch of an optional can't match
+    # it -- drop it so the loop only tries branches that could succeed.
+    candidates = [t for t in args if not _is_none_type(t)]
+    errors: list[ValueError] = []
+    for t in candidates:
+        try:
+            return try_parse_value_as_type(value, t)
+        except ValueError as e:
+            errors.append(e)
+    detail = ''.join(f'\n\t{", ".join(e.args)}' for e in errors)
+    raise ValueError(
+        f'Could not coerce value of type ({get_display_type_from_value(value)!r}) '
+        f'as any of the types in the union: {get_display_type(args)}, '
+        f'value :: {value!r}, from errors: {detail}',
+    ) from (errors[0] if errors else None)
 
 
 def try_parse_value_as_type(value: Any, dtype: Any) -> Any:
@@ -72,122 +169,73 @@ def try_parse_value_as_type(value: Any, dtype: Any) -> Any:
     Try to parse a value as a specific type.
     Raise a ValueError if it can't be parsed.
     """
-    if dtype is None or isinstance(dtype, type(None)):
+    # Any (or an unparameterised, unrecognised construct) is accepted as-is.
+    if dtype is Any:
+        return value
+
+    # None / NoneType.
+    if dtype is None or dtype is type(None):
         if value is None:
             return None
-        raise ValueError(f'Expected None, got {type(value)} for {value!r}')
-
-    if dtype is Any:
-        return value
-
-    if isinstance(dtype, UnionType):
-        dtype = get_args(dtype)
-
-    if dtype is Any:
-        return value
-
-    if isinstance(dtype, tuple):
-        # union type
-        if len(dtype) == 0:
-            # any
-            return value
-
-        # union type
-        if value is None:
-            if any(isinstance(t, type(None)) or t is type(None) for t in dtype):
-                return None
-            raise ValueError(
-                f'Expected (non-optional) {get_display_type(dtype)}, got None',
-            )
-
-        union_parse_errors: list[ValueError] = []
-        for t in dtype:
-            try:
-                return try_parse_value_as_type(value, t)
-            except ValueError as e:
-                # debugging
-                if not (t is None or isinstance(t, type(None))):
-                    # skip optional errors
-                    union_parse_errors.append(e)
-                continue
-        if len(union_parse_errors) == 1:
-            message = (
-                f'Could not coerce value of type ({get_display_type_from_value(value)!r}) '
-                f'as any of the types in the union: {get_display_type(dtype)}, '
-                f'value :: {value!r}'
-            )
-            raise ValueError(message) from union_parse_errors[0]
-        error_message = ''.join(
-            [f'\n\t{", ".join(e.args)}' for e in union_parse_errors],
+        raise ValueError(
+            f'Expected None, got {get_display_type_from_value(value)} for {value!r}',
         )
-        message = (
-            f'Could not coerce value of type ({get_display_type_from_value(value)!r}) '
-            f'as any of the types in the union: {get_display_type(dtype)}, value :: {value!r}, '
-            f'from errors: {error_message}'
-        )
-        raise ValueError(message)
 
-    if isinstance(dtype, tuple) and len(dtype) == 1:
-        return try_parse_value_as_type(value, dtype[0])
+    origin = get_origin(dtype)
+    args = get_args(dtype)
 
-    if dtype is list or get_origin(dtype) is list:
-        if not isinstance(value, list):
-            raise ValueError(
-                f'Expected list, got {get_display_type_from_value(value)} for {value!r}',
-            )
-        list_types = get_args(dtype)
-        if len(list_types) != 1:
+    # Type *forms* that aren't plain classes: unions and literals.
+    match origin:
+        case types.UnionType | typing.Union:  # `X | Y`, `Optional[X]`, `Union[...]`
+            return _parse_union(value, args)
+        case typing.Literal:
+            if value not in args:
+                raise ValueError(f'Expected literal {args}, got {value!r}')
             return value
-        return [try_parse_value_as_type(v, list_types[0]) for v in value]
-    if dtype is dict or get_origin(dtype) is dict:
-        if not isinstance(value, dict):
-            raise ValueError(
-                f'Expected dict, got {get_display_type_from_value(value)} for {value!r}',
-            )
-        dict_types = get_args(dtype)
-        if len(dict_types) != 2:
-            # no need for casting
+
+    # Otherwise dtype resolves to a concrete class: the generic's origin
+    # (`list[str]` -> list) or the bare type itself (dict, a TypedDict, a
+    # DeserializableDataclass, int, ...).
+    cls = origin or dtype
+
+    # Parameterised/bare containers, with element coercion.
+    if parser := CONTAINER_PARSERS.get(cls):
+        return parser(value, args)
+
+    if not isclass(cls):
+        # Not an introspectable class (TypeVar, ForwardRef, unrecognised special
+        # form). Can't coerce -- surface as ValueError per this function's
+        # contract, so a union branch falls through instead of raising TypeError.
+        raise ValueError(f'Unknown type {get_display_type(dtype)}')
+
+    # Nested dataclasses, built recursively from their mapping form.
+    if issubclass(cls, DeserializableDataclass):
+        match value:
+            case dict():
+                return cls.instantiate(**value)
+            case cls():  # already deserialised -- pass through
+                return value
+            case _:
+                raise ValueError(f'Expected dict, got {type(value)} for {value!r}')
+
+    # Anything whose runtime type is a dict subclass: a plain dict OR a TypedDict
+    # (a TypedDict's MRO includes dict, so it lands here for free -- no
+    # is_typeddict needed). Accept any mapping as-is; TypedDicts carry no runtime
+    # key/value validation.
+    if issubclass(cls, dict):
+        match value:
+            case dict():
+                return value
+            case _:
+                raise ValueError(
+                    f'Expected dict, got {get_display_type_from_value(value)} for {value!r}',
+                )
+
+    # Scalars: pass a correct instance through, else coerce a primitive.
+    match value:
+        case _ if isinstance(value, cls):
             return value
-        return {k: try_parse_value_as_type(v, dict_types[1]) for k, v in value.items()}
-    if dtype is set or get_origin(dtype) is set:
-        if not isinstance(value, (set, list)):
-            raise ValueError(
-                f'Expected set, got {get_display_type_from_value(value)} for {value!r}',
-            )
-        set_types = get_args(dtype)
-        if len(set_types) != 1:
-            # set[any]
-            return set(value)
-        return {try_parse_value_as_type(v, set_types[0]) for v in value}
-    if dtype is tuple or get_origin(dtype) is tuple:
-        if not isinstance(value, (tuple, list)):
-            raise ValueError(
-                f'Expected tuple, got {get_display_type_from_value(value)} for {value!r}',
-            )
-        tuple_types = get_args(dtype)
-        if len(tuple_types) == 0:
-            return tuple(value)
-        if len(tuple_types) != len(value):
-            raise ValueError(
-                f'Expected tuple of length {len(tuple_types)}, got {len(value)} for {value!r}',
-            )
-        return tuple(try_parse_value_as_type(v, t) for v, t in zip(value, tuple_types))
-
-    if get_origin(dtype) is Literal:
-        arg_values = get_args(dtype)
-        if value not in arg_values:
-            raise ValueError(f'Expected literal {arg_values}, got {value!r}')
-        return value
-
-    if isinstance(value, dtype):
-        return value
-
-    if dtype is not None and issubclass(dtype, DeserializableDataclass):
-        if not isinstance(value, dict):
-            raise ValueError(f'Expected dict, got {type(value)} for {value!r}')
-        return dtype.instantiate(**value)
-
-    if any(dtype is prim for prim in (str, int, bool, float, bytes)):
-        return dtype(value)
-
-    raise ValueError(f'Unknown type {get_display_type(dtype)}')
+        case _ if cls in PRIMITIVES:
+            return cls(value)
+        case _:
+            raise ValueError(f'Unknown type {get_display_type(dtype)}')

--- a/test/test_parse_values.py
+++ b/test/test_parse_values.py
@@ -2,11 +2,21 @@
 Test module for checking the parsing of values in the config
 """
 
-from typing import Any, Literal
+from typing import Any, Literal, Optional, TypedDict, TypeVar, Union
 from unittest import TestCase
 
 from cpg_infra.config import CPGDatasetConfig, CPGInfrastructureConfig
 from cpg_infra.config.deserializabledataclass import try_parse_value_as_type
+
+
+class _Settings(TypedDict, total=False):
+    """A TypedDict used to check pass-through parsing."""
+
+    who_can_post: str
+
+
+# A non-class type used to check TypeError-free handling of exotic constructs.
+T = TypeVar('T')
 
 
 class TestParseValues(TestCase):
@@ -199,3 +209,69 @@ class TestParseValues(TestCase):
         self.assertEqual(1, try_parse_value_as_type(1, Any))
         self.assertEqual('hi', try_parse_value_as_type('hi', Any))
         self.assertEqual({'hi': 'world'}, try_parse_value_as_type({'hi': 'world'}, Any))
+
+    def test_variable_length_tuple(self):
+        """tuple[X, ...] coerces every element to X, regardless of length"""
+        dtype = tuple[int, ...]
+        self.assertTupleEqual((), try_parse_value_as_type([], dtype))
+        self.assertTupleEqual((1,), try_parse_value_as_type(['1'], dtype))
+        self.assertTupleEqual(
+            (1, 2, 3),
+            try_parse_value_as_type(['1', '2', '3'], dtype),
+        )
+
+    def test_variable_length_tuple_failure(self):
+        """tuple[X, ...] rejects an element that can't be coerced to X"""
+        dtype = tuple[int, ...]
+        with self.assertRaises(ValueError):
+            try_parse_value_as_type(['1', 'nope'], dtype)
+
+    def test_typing_union(self):
+        """typing.Union (not just `X | Y`) is routed through union parsing"""
+        dtype = Union[int, str]
+        self.assertEqual(1, try_parse_value_as_type('1', dtype))
+        self.assertEqual('hello', try_parse_value_as_type('hello', dtype))
+
+    def test_typing_optional_none(self):
+        """Optional[X] accepts None"""
+        dtype = Optional[int]
+        self.assertIsNone(try_parse_value_as_type(None, dtype))
+        self.assertEqual(1, try_parse_value_as_type('1', dtype))
+
+    def test_union_failure_chains_cause(self):
+        """A failed union coercion chains the first branch error as its cause"""
+        with self.assertRaises(ValueError) as ctx:
+            try_parse_value_as_type('hello', int | float)
+        self.assertIsInstance(ctx.exception.__cause__, ValueError)
+
+    def test_typeddict_passthrough(self):
+        """A TypedDict is treated as a plain dict: any mapping passes, unvalidated"""
+        value = {'who_can_post': 'ANYONE', 'unlisted_key': 123}
+        self.assertDictEqual(value, try_parse_value_as_type(value, _Settings))
+
+    def test_typeddict_rejects_non_dict(self):
+        """A TypedDict field still rejects a non-dict value"""
+        with self.assertRaises(ValueError):
+            try_parse_value_as_type(['not', 'a', 'dict'], _Settings)
+
+    def test_dataclass_instance_passthrough(self):
+        """An already-deserialised dataclass instance passes through unchanged"""
+        instance = try_parse_value_as_type(
+            {'dataset': 'DATASET', 'budgets': {}, 'gcp': {'project': 'dataset-1234'}},
+            CPGDatasetConfig,
+        )
+        self.assertIs(
+            instance,
+            try_parse_value_as_type(instance, CPGDatasetConfig),
+        )
+
+    def test_non_class_type_raises_value_error(self):
+        """A non-class type (e.g. a TypeVar) raises ValueError, not TypeError"""
+        with self.assertRaises(ValueError):
+            try_parse_value_as_type(1, T)
+
+    def test_union_with_non_class_branch_falls_through(self):
+        """A non-class union branch is skipped so a valid branch still matches"""
+        # a lone TypeVar branch is the point of this test
+        dtype = Union[T, int]  # type: ignore[valid-type]
+        self.assertEqual(1, try_parse_value_as_type('1', dtype))


### PR DESCRIPTION
## Summary

Rewrites `try_parse_value_as_type` (the `DeserializableDataclass` type-coercion routine) from a long cascaded `if`-chain into an origin-based `match`/`case` dispatch, with the container handling split into small per-type parser helpers.

Independent of PR #373 (no changes to `config.py`); this is a standalone cleanup of `cpg_infra/config/deserializabledataclass.py`.

## Behavioural changes

- **TypedDict support.** A TypedDict is a `dict` subclass at runtime (its MRO includes `dict`), so it's accepted as a plain dict with no key/value validation — no `typing.is_typeddict` needed. This removes the reason `config.py` keeps `group_settings` as a bare `dict[str, str]`.
- Route `typing.Union` / `Optional` through union parsing (previously only the `X | Y` syntax was handled).
- Pass an already-deserialised dataclass instance through unchanged.

## Bug fixes surfaced by the rewrite

- **Variable-length tuples.** `tuple[X, ...]` now coerces every element to `X` regardless of length (was rejected as "expected length 2").
- Drop the stray `']'` in `get_display_type`'s tuple branch, which was leaking into union coercion error messages.
- Restore exception-cause chaining on failed union coercion.

## Review follow-ups

- Annotate `PRIMITIVES` and `CONTAINER_PARSERS` as `Final`.
- Extract `_is_none_type` and filter `NoneType` out of union args so the loop only tries branches that can match.
- Guard `issubclass`/`isinstance` with `isclass(cls)`, raising `ValueError` (not `TypeError`) for non-class constructs — honours the documented contract and lets union branches fall through.

## Tests

Adds coverage for the new behaviours and each fix (variable-length tuples, `typing.Union`/`Optional`, union-failure cause chaining, TypedDict pass-through, dataclass-instance pass-through, non-class guard). 34 tests pass; ruff clean.