### PR TITLE
Billing aggregate function for GCP export increase to 24 hours from 8 hours

### DIFF
--- a/cpg_infra/billing_aggregator/driver.py
+++ b/cpg_infra/billing_aggregator/driver.py
@@ -341,7 +341,7 @@ class BillingAggregator(CpgInfrastructurePlugin):
                 # atm default_interval_hours is usually set to 1H,
                 # 8H seems to be a good start as interval for GCP,
                 # but might need to be extended if we find that is not sufficient
-                default_interval_hours = 8 * default_interval_hours
+                default_interval_hours = 24 * default_interval_hours
                 start_minute = 1
 
             if function in ['hail', 'seqr', 'seqr24', 'gcp']:

--- a/cpg_infra/billing_aggregator/driver.py
+++ b/cpg_infra/billing_aggregator/driver.py
@@ -339,8 +339,8 @@ class BillingAggregator(CpgInfrastructurePlugin):
                 # around the understanding that data might be delayed by a few hours."
                 #
                 # atm default_interval_hours is usually set to 1H,
-                # 8H was to be a good start as interval for GCP,
-                # Based on billing records investigation 8H only covers around 80%,
+                # 8H was a good start as interval for GCP, however
+                # based on billing records investigation 8H only covers around 80%,
                 # 24H should give us close to 100% of all the billing records.
                 # Again, we might need to extend if we find that is not sufficient
                 default_interval_hours = 24 * default_interval_hours

--- a/cpg_infra/billing_aggregator/driver.py
+++ b/cpg_infra/billing_aggregator/driver.py
@@ -339,8 +339,10 @@ class BillingAggregator(CpgInfrastructurePlugin):
                 # around the understanding that data might be delayed by a few hours."
                 #
                 # atm default_interval_hours is usually set to 1H,
-                # 8H seems to be a good start as interval for GCP,
-                # but might need to be extended if we find that is not sufficient
+                # 8H was to be a good start as interval for GCP,
+                # Based on billing records investigation 8H only covers around 80%,
+                # 24H should give us close to 100% of all the billing records.
+                # Again, we might need to extend if we find that is not sufficient
                 default_interval_hours = 24 * default_interval_hours
                 start_minute = 1
 


### PR DESCRIPTION
This PR increasing limit captured by GCP Billing Aggregate function from 8 to 24 hours.

Based on investigation for June/July 2026 billing records, GCP exports billing information with larger delays. 
Current 8 hours interval only captures around 80% of billing records. 24 hrs will get close to 100%.
GCP cloud run takes less than 3minutes for those 8 hours, so increase to 24hrs would not be a problem.

There are few billing records like tax, which have delays a few days, but we do not include GST in metamist billing.
The other very small $ amount of cost adjustments, etc are a few days late as well, but those are in <$1.