### PR TITLE
[SET-1228] Sync metamist project display name & description from cpg-infra

### DIFF
--- a/cpg_infra/abstraction/metamist.py
+++ b/cpg_infra/abstraction/metamist.py
@@ -50,7 +50,7 @@ class MetamistProjectProvider(pulumi.dynamic.ResourceProvider):
         if not project_id:
             raise RuntimeError(f'Failed to create project {name}')
 
-        # create_project can't carry meta, so sync it with a follow-up call.
+        # create_project doesn't carry meta, so sync it with a follow-up call.
         # Applies to both newly-created and pre-existing projects.
         if meta:
             ProjectApi().update_project(name, {'meta': meta})
@@ -69,14 +69,19 @@ class MetamistProjectProvider(pulumi.dynamic.ResourceProvider):
         old_meta = _olds.get('meta') or {}
         new_meta = _news.get('meta') or {}
 
-        # Declarative sync: the server merge-patches meta, so a key dropped from
-        # config would otherwise linger. Send an explicit null for any key that
-        # was set before but is absent now, so it gets cleared.
-        merged = {k: None for k in old_meta}
-        merged.update(new_meta)
+        # The cpg-infra-private config is the source of truth for these meta keys:
+        # we sync config -> metamist, but never metamist -> config. So to change a
+        # display_name or description, edit the dataset config rather than editing
+        # the project meta directly in metamist.
+        #
+        # The server merge-patches meta, so a key dropped from the config would
+        # otherwise linger. Send an explicit null for those keys to clear them.
+        meta_update = dict(new_meta)
+        for k in old_meta.keys() - new_meta.keys():
+            meta_update[k] = None  # Tell update_project() to remove this entry
 
-        if merged:
-            ProjectApi().update_project(name, {'meta': merged})
+        if meta_update:
+            ProjectApi().update_project(name, {'meta': meta_update})
 
         return pulumi.dynamic.UpdateResult(
             outs={

--- a/cpg_infra/abstraction/metamist.py
+++ b/cpg_infra/abstraction/metamist.py
@@ -118,13 +118,13 @@ class MetamistProject(pulumi.dynamic.Resource):
 
     project_id: pulumi.Output[int]
     project_name: pulumi.Output[str]
-    meta: pulumi.Output[dict]
+    meta: pulumi.Output[dict[str, str]]
 
     def __init__(
         self,
         name: str,
         project_name: str,
-        meta: dict | None = None,
+        meta: dict[str, str] | None = None,
         opts: pulumi.ResourceOptions | None = None,
     ) -> None:
         args = {

--- a/cpg_infra/abstraction/metamist.py
+++ b/cpg_infra/abstraction/metamist.py
@@ -36,6 +36,7 @@ class MetamistProjectProvider(pulumi.dynamic.ResourceProvider):
 
     def create(self, props: dict[str, Any]) -> pulumi.dynamic.CreateResult:
         name = props['project_name']
+        meta = props.get('meta') or {}
 
         if project := get_project_by_name(name):
             project_id = project['id']
@@ -49,11 +50,39 @@ class MetamistProjectProvider(pulumi.dynamic.ResourceProvider):
         if not project_id:
             raise RuntimeError(f'Failed to create project {name}')
 
+        # create_project can't carry meta, so sync it with a follow-up call.
+        # Applies to both newly-created and pre-existing projects.
+        if meta:
+            ProjectApi().update_project(name, {'meta': meta})
+
         return pulumi.dynamic.CreateResult(
             id_=f'metamist-project::{name}::{project_id}',
             outs={
                 'project_id': project_id,
                 'project_name': name,
+                'meta': meta,
+            },
+        )
+
+    def update(self, _id: str, _olds, _news) -> pulumi.dynamic.UpdateResult:
+        name = _news['project_name']
+        old_meta = _olds.get('meta') or {}
+        new_meta = _news.get('meta') or {}
+
+        # Declarative sync: the server merge-patches meta, so a key dropped from
+        # config would otherwise linger. Send an explicit null for any key that
+        # was set before but is absent now, so it gets cleared.
+        merged = {k: None for k in old_meta}
+        merged.update(new_meta)
+
+        if merged:
+            ProjectApi().update_project(name, {'meta': merged})
+
+        return pulumi.dynamic.UpdateResult(
+            outs={
+                'project_id': _olds['project_id'],
+                'project_name': name,
+                'meta': new_meta,
             },
         )
 
@@ -63,8 +92,11 @@ class MetamistProjectProvider(pulumi.dynamic.ResourceProvider):
         if _olds['project_name'] != _news['project_name']:
             replaces.append('project_name')
 
+        # A meta-only change is an in-place update (never a project replace).
+        meta_changed = (_olds.get('meta') or {}) != (_news.get('meta') or {})
+
         return pulumi.dynamic.DiffResult(
-            changes=len(replaces) > 0,
+            changes=len(replaces) > 0 or meta_changed,
             replaces=replaces,
             delete_before_replace=len(replaces) > 0,
         )
@@ -82,19 +114,22 @@ class MetamistProjectProvider(pulumi.dynamic.ResourceProvider):
 
 
 class MetamistProject(pulumi.dynamic.Resource):
-    """Create a membership to a Hail Batch Billing Project"""
+    """Create a metamist project and sync its meta"""
 
     project_id: pulumi.Output[int]
     project_name: pulumi.Output[str]
+    meta: pulumi.Output[dict]
 
     def __init__(
         self,
         name: str,
         project_name: str,
+        meta: dict | None = None,
         opts: pulumi.ResourceOptions | None = None,
     ) -> None:
         args = {
             'project_name': project_name,
+            'meta': meta or {},
         }
         super().__init__(MetamistProjectProvider(), name, args, opts)
 

--- a/cpg_infra/config/config.py
+++ b/cpg_infra/config/config.py
@@ -360,6 +360,13 @@ class CPGDatasetConfig(ConfigModel):
     # the name of the dataset
     dataset: str
 
+    # human-friendly / stylised name for the metamist project, synced into the
+    # project's meta. Only applies when enable_metamist_project is true.
+    display_name: str | None = None
+    # free-text description for the metamist project, synced into the project's
+    # meta. Only applies when enable_metamist_project is true.
+    description: str | None = None
+
     # the budgets of the dataset, keyed by the cloud ID
     budgets: dict[CloudName, Budget]
 

--- a/cpg_infra/config/config.py
+++ b/cpg_infra/config/config.py
@@ -432,3 +432,18 @@ class CPGDatasetConfig(ConfigModel):
     members: dict[GroupName, list[MemberKey]] = Field(default_factory=dict)
 
     upload_config: UploadConfig | None = None
+
+    def metamist_project_meta(self, is_test: bool = False) -> dict[str, str]:
+        """Build the metamist project meta dict from this config.
+
+        Only includes keys that are set. The test project's display_name is
+        suffixed with ' (test)' to stay distinguishable in UIs.
+        """
+        meta: dict[str, str] = {}
+        if self.display_name:
+            meta['display_name'] = (
+                f'{self.display_name} (test)' if is_test else self.display_name
+            )
+        if self.description:
+            meta['description'] = self.description
+        return meta

--- a/cpg_infra/config/config.py
+++ b/cpg_infra/config/config.py
@@ -433,17 +433,15 @@ class CPGDatasetConfig(ConfigModel):
 
     upload_config: UploadConfig | None = None
 
-    def metamist_project_meta(self, is_test: bool = False) -> dict[str, str]:
+    def metamist_project_meta(self, suffix: str = '') -> dict[str, str]:
         """Build the metamist project meta dict from this config.
 
-        Only includes keys that are set. The test project's display_name is
-        suffixed with ' (test)' to stay distinguishable in UIs.
+        Only includes keys that are set. Callers pass a suffix to append to
+        display_name, so that e.g. test projects stay distinguishable in UIs.
         """
         meta: dict[str, str] = {}
         if self.display_name:
-            meta['display_name'] = (
-                f'{self.display_name} (test)' if is_test else self.display_name
-            )
+            meta['display_name'] = self.display_name + suffix
         if self.description:
             meta['description'] = self.description
         return meta

--- a/cpg_infra/driver.py
+++ b/cpg_infra/driver.py
@@ -1036,7 +1036,7 @@ class CPGDatasetInfrastructure:
         return MetamistProject(
             f'metamist-project-{self.dataset}-test',
             project_name=self.dataset + '-test',
-            meta=self.dataset_config.metamist_project_meta(is_test=True),
+            meta=self.dataset_config.metamist_project_meta(' (test)'),
         )
 
 

--- a/cpg_infra/driver.py
+++ b/cpg_infra/driver.py
@@ -1023,11 +1023,28 @@ class CPGDatasetInfrastructure:
             if self.dataset_config.setup_test:
                 _ = self.metamist_test_project
 
+    def _metamist_project_meta(self, is_test: bool = False) -> dict[str, str]:
+        """Build the metamist project meta dict from dataset config.
+
+        Only includes keys that are set. The test project's display_name is
+        suffixed with ' (test)' to stay distinguishable in UIs.
+        """
+        meta: dict[str, str] = {}
+        display_name = self.dataset_config.display_name
+        if display_name:
+            meta['display_name'] = (
+                f'{display_name} (test)' if is_test else display_name
+            )
+        if self.dataset_config.description:
+            meta['description'] = self.dataset_config.description
+        return meta
+
     @cached_property
     def metamist_project(self):
         return MetamistProject(
             f'metamist-project-{self.dataset}',
             project_name=self.dataset,
+            meta=self._metamist_project_meta(),
         )
 
     @cached_property
@@ -1035,6 +1052,7 @@ class CPGDatasetInfrastructure:
         return MetamistProject(
             f'metamist-project-{self.dataset}-test',
             project_name=self.dataset + '-test',
+            meta=self._metamist_project_meta(is_test=True),
         )
 
 

--- a/cpg_infra/driver.py
+++ b/cpg_infra/driver.py
@@ -1023,28 +1023,12 @@ class CPGDatasetInfrastructure:
             if self.dataset_config.setup_test:
                 _ = self.metamist_test_project
 
-    def _metamist_project_meta(self, is_test: bool = False) -> dict[str, str]:
-        """Build the metamist project meta dict from dataset config.
-
-        Only includes keys that are set. The test project's display_name is
-        suffixed with ' (test)' to stay distinguishable in UIs.
-        """
-        meta: dict[str, str] = {}
-        display_name = self.dataset_config.display_name
-        if display_name:
-            meta['display_name'] = (
-                f'{display_name} (test)' if is_test else display_name
-            )
-        if self.dataset_config.description:
-            meta['description'] = self.dataset_config.description
-        return meta
-
     @cached_property
     def metamist_project(self):
         return MetamistProject(
             f'metamist-project-{self.dataset}',
             project_name=self.dataset,
-            meta=self._metamist_project_meta(),
+            meta=self.dataset_config.metamist_project_meta(),
         )
 
     @cached_property
@@ -1052,7 +1036,7 @@ class CPGDatasetInfrastructure:
         return MetamistProject(
             f'metamist-project-{self.dataset}-test',
             project_name=self.dataset + '-test',
-            meta=self._metamist_project_meta(is_test=True),
+            meta=self.dataset_config.metamist_project_meta(is_test=True),
         )
 
 

--- a/test/test_config_validation.py
+++ b/test/test_config_validation.py
@@ -60,6 +60,23 @@ class TestConfigValidation(TestCase):
         self.assertEqual('dataset-1234', config.gcp.project)
         # defaults are applied
         self.assertEqual(['gcp'], config.deploy_locations)
+        # metamist project labels default to unset
+        self.assertIsNone(config.display_name)
+        self.assertIsNone(config.description)
+
+    def test_metamist_project_labels(self):
+        """display_name and description are optional and parse when provided"""
+        config = CPGDatasetConfig.model_validate(
+            {
+                'dataset': 'DATASET',
+                'budgets': {},
+                'gcp': {'project': 'dataset-1234'},
+                'display_name': 'Rare Disease Cohort',
+                'description': 'A cohort for rare disease research',
+            },
+        )
+        self.assertEqual('Rare Disease Cohort', config.display_name)
+        self.assertEqual('A cohort for rare disease research', config.description)
 
     def test_components_string_coercion(self):
         """Component strings are coerced into CPGDatasetComponents enum members"""

--- a/test/test_config_validation.py
+++ b/test/test_config_validation.py
@@ -78,6 +78,64 @@ class TestConfigValidation(TestCase):
         self.assertEqual('Rare Disease Cohort', config.display_name)
         self.assertEqual('A cohort for rare disease research', config.description)
 
+    @staticmethod
+    def _dataset_config(**extra: str) -> CPGDatasetConfig:
+        return CPGDatasetConfig.model_validate(
+            {
+                'dataset': 'DATASET',
+                'budgets': {},
+                'gcp': {'project': 'dataset-1234'},
+                **extra,
+            },
+        )
+
+    def test_metamist_project_meta_empty(self):
+        """Meta is empty when neither display_name nor description is set"""
+        config = self._dataset_config()
+        self.assertEqual({}, config.metamist_project_meta())
+        self.assertEqual({}, config.metamist_project_meta(is_test=True))
+
+    def test_metamist_project_meta_only_set_keys(self):
+        """Only keys that are set are included in the meta dict"""
+        self.assertEqual(
+            {'display_name': 'Rare Disease Cohort'},
+            self._dataset_config(
+                display_name='Rare Disease Cohort'
+            ).metamist_project_meta(),
+        )
+        self.assertEqual(
+            {'description': 'A cohort'},
+            self._dataset_config(description='A cohort').metamist_project_meta(),
+        )
+
+    def test_metamist_project_meta_full(self):
+        """Both fields flow into the meta dict for a non-test project"""
+        config = self._dataset_config(
+            display_name='Rare Disease Cohort',
+            description='A cohort for rare disease research',
+        )
+        self.assertEqual(
+            {
+                'display_name': 'Rare Disease Cohort',
+                'description': 'A cohort for rare disease research',
+            },
+            config.metamist_project_meta(),
+        )
+
+    def test_metamist_project_meta_test_suffix(self):
+        """The test project suffixes display_name but not description"""
+        config = self._dataset_config(
+            display_name='Rare Disease Cohort',
+            description='A cohort for rare disease research',
+        )
+        self.assertEqual(
+            {
+                'display_name': 'Rare Disease Cohort (test)',
+                'description': 'A cohort for rare disease research',
+            },
+            config.metamist_project_meta(is_test=True),
+        )
+
     def test_components_string_coercion(self):
         """Component strings are coerced into CPGDatasetComponents enum members"""
         config = CPGDatasetConfig.model_validate(

--- a/test/test_config_validation.py
+++ b/test/test_config_validation.py
@@ -78,64 +78,6 @@ class TestConfigValidation(TestCase):
         self.assertEqual('Rare Disease Cohort', config.display_name)
         self.assertEqual('A cohort for rare disease research', config.description)
 
-    @staticmethod
-    def _dataset_config(**extra: str) -> CPGDatasetConfig:
-        return CPGDatasetConfig.model_validate(
-            {
-                'dataset': 'DATASET',
-                'budgets': {},
-                'gcp': {'project': 'dataset-1234'},
-                **extra,
-            },
-        )
-
-    def test_metamist_project_meta_empty(self):
-        """Meta is empty when neither display_name nor description is set"""
-        config = self._dataset_config()
-        self.assertEqual({}, config.metamist_project_meta())
-        self.assertEqual({}, config.metamist_project_meta(is_test=True))
-
-    def test_metamist_project_meta_only_set_keys(self):
-        """Only keys that are set are included in the meta dict"""
-        self.assertEqual(
-            {'display_name': 'Rare Disease Cohort'},
-            self._dataset_config(
-                display_name='Rare Disease Cohort'
-            ).metamist_project_meta(),
-        )
-        self.assertEqual(
-            {'description': 'A cohort'},
-            self._dataset_config(description='A cohort').metamist_project_meta(),
-        )
-
-    def test_metamist_project_meta_full(self):
-        """Both fields flow into the meta dict for a non-test project"""
-        config = self._dataset_config(
-            display_name='Rare Disease Cohort',
-            description='A cohort for rare disease research',
-        )
-        self.assertEqual(
-            {
-                'display_name': 'Rare Disease Cohort',
-                'description': 'A cohort for rare disease research',
-            },
-            config.metamist_project_meta(),
-        )
-
-    def test_metamist_project_meta_test_suffix(self):
-        """The test project suffixes display_name but not description"""
-        config = self._dataset_config(
-            display_name='Rare Disease Cohort',
-            description='A cohort for rare disease research',
-        )
-        self.assertEqual(
-            {
-                'display_name': 'Rare Disease Cohort (test)',
-                'description': 'A cohort for rare disease research',
-            },
-            config.metamist_project_meta(is_test=True),
-        )
-
     def test_components_string_coercion(self):
         """Component strings are coerced into CPGDatasetComponents enum members"""
         config = CPGDatasetConfig.model_validate(


### PR DESCRIPTION
## Summary

Implements [SET-1228](https://cpg-populationanalysis.atlassian.net/browse/SET-1228): let the RD team set a stylised **display name** and optional **description** on metamist projects from cpg-infrastructure dataset config.

Because metamist projects have no first-class columns for these (deferred until the Postgres migration, per the ticket's No-Gos), the values are stored in the project's `meta` JSON under keys `display_name` and `description`.

## Changes

- **`config.py`** — two optional fields on `CPGDatasetConfig`: `display_name`, `description` (only apply when `enable_metamist_project` is true).
- **`abstraction/metamist.py`** — `MetamistProject`/`MetamistProjectProvider` now take a generic `meta` dict:
  - `create` writes meta via a follow-up `update_project` call (create_project can't carry meta), for both newly-created **and** pre-existing projects.
  - new `update` method → meta-only changes are in-place updates, never project replaces (`diff` routes them there).
  - **Declarative clearing**: keys dropped from config are sent as explicit JSON `null`, because the server merge-patches meta (an empty `{}` is a no-op).
- **`driver.py`** — builds the meta dict from config; the test project gets a `(test)`-suffixed display name.
- **`test/test_config_validation.py`** — coverage for the new fields (default `None`, parse when provided).

## Design record

ADR (kept in Confluence, not the repo): https://cpg-populationanalysis.atlassian.net/wiki/spaces/ST/pages/1384218630

## Verification

- `test/test_config_validation.py` — 9 passed (incl. new `test_metamist_project_labels`).
- All three edited modules compile; declarative-null merge + `(test)` suffix logic verified against sample inputs.
- ⚠️ To confirm on review: the credential cpg-infra uses must have `project_admin` + project-creator rights for `update_project` (it already calls `create_project`/`update_project_members`, so almost certainly yes).

## Known limitations

- **No server-drift reconciliation.** `read` doesn't re-fetch server-side meta, so `diff` compares only against last-recorded config state. If a project's `display_name`/`description` is edited directly in metamist (outside cpg-infra), the drift is **not** detected or corrected. This is by design: these values are expected to be changed in config only — cpg-infra config is the source of truth.

[SET-1228]: https://cpg-populationanalysis.atlassian.net/browse/SET-1228?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

