### PR TITLE
Create external-repository-reader role

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,8 +126,8 @@ Members have different roles within a dataset, those roles include:
 - upload:
   - Upload data into upload buckets as specified in the `datasets/$DATASET/upload.yaml` file.
 - external-repository-reader
-  - Read access to data in main. 
-  - Developed to support Terra Data Repository service account access to self-hosted production data in CPG buckets. 
+  - Read access to data in main.
+  - Developed to support Terra Data Repository service account access to self-hosted production data in CPG buckets.
 
 ## Setup
 

--- a/README.md
+++ b/README.md
@@ -125,6 +125,9 @@ Members have different roles within a dataset, those roles include:
   - Access to view main-web bucket through web server
 - upload:
   - Upload data into upload buckets as specified in the `datasets/$DATASET/upload.yaml` file.
+- external-repository-reader
+  - Read access to data in main. 
+  - Developed to support Terra Data Repository service account access to self-hosted production data in CPG buckets. 
 
 ## Setup
 

--- a/README.md
+++ b/README.md
@@ -126,8 +126,8 @@ Members have different roles within a dataset, those roles include:
 - upload:
   - Upload data into upload buckets as specified in the `datasets/$DATASET/upload.yaml` file.
 - external-repository-reader
-  - Read access to data in main.
-  - Developed to support Terra Data Repository service account access to self-hosted production data in CPG buckets.
+  - Read access to data in main. This is distinct from the `data-manager` role as it only grants read access to main and no additional access to any other buckets or services.
+  - Developed to support Terra Data Repository service account access to self-hosted production data in CPG buckets. Do not assign this role to a human user.
 
 ## Setup
 

--- a/cpg_infra/config/config.py
+++ b/cpg_infra/config/config.py
@@ -25,6 +25,7 @@ GroupName = Literal[
     'web-access',
     'release-access',
     'tmp-main-read-access',
+    'external-repository-reader',
 ]
 
 

--- a/cpg_infra/driver.py
+++ b/cpg_infra/driver.py
@@ -1198,6 +1198,7 @@ class CPGDatasetCloudInfrastructure:
             self.metadata_write_group,
             self.web_access_group,
             self.release_access_group,
+            self.external_repository_reader_group,
         ]
 
         for group in groups:
@@ -1364,6 +1365,10 @@ class CPGDatasetCloudInfrastructure:
     @cached_property
     def release_access_group(self):
         return self.create_group('release-access')
+
+    @cached_property
+    def external_repository_reader_group(self):
+        return self.create_group('external-repository-reader')
 
     # access groups
 
@@ -1784,6 +1789,13 @@ class CPGDatasetCloudInfrastructure:
             'main-read-main-bucket-read',
             self.main_bucket,
             self.main_read_group,
+            BucketMembership.READ,
+        )
+
+        self.infra.add_member_to_bucket(
+            'external-repository-reader-main-bucket-read',
+            self.main_bucket,
+            self.external_repository_reader_group,
             BucketMembership.READ,
         )
 


### PR DESCRIPTION

### Summary
Added a new `external-repository-reader` role that grants members READ access to the main bucket only. Required to support access for a Terra Data Repository (TDR) dataset that requires service account access with READ permissions. 

### Changes
* `cpg_infra/config/config.py` — added 'external-repository-reader' to the GroupName literal so it's a valid key under members: in members.yaml.
* `cpg_infra/driver.py`:
    * New external_repository_reader_group cached property that creates the external-repository-reader group.
    * Group added to the groups list in setup_externally_specified_members so users listed under external-repository-reader: in members.yaml are added to it.
    * Direct READ binding on main_bucket (and only that bucket) added in setup_storage_main_bucket_permissions.

### External resources
* [ Slack conversation discussing the change ](https://centrepopgen.slack.com/archives/C018KFBCR1C/p1785376464664549)
* [Proposal for Terra pilot](https://cpg-populationanalysis.atlassian.net/wiki/spaces/CP/pages/1349091390/Proposal+Terra+data+and+permissions+models)