### PR TITLE
Relaxing type for Pulumi's runtime.

### DIFF
--- a/cpg_infra/abstraction/metamist.py
+++ b/cpg_infra/abstraction/metamist.py
@@ -134,7 +134,12 @@ class MetamistProject(pulumi.dynamic.Resource):
 
     project_id: pulumi.Output[int]
     project_name: pulumi.Output[str]
-    meta: pulumi.Output[dict[str, str | list[str]]]
+    # Pulumi's translate_output_properties can't destructure a PEP 604 union
+    # (str | list[str]) inside a generic — it raises AssertionError when a
+    # dict value happens to be a list. `dict[str, Any]` is the tightest
+    # runtime-safe annotation; the constructor parameter below keeps the
+    # narrower contract for callers and type checkers.
+    meta: pulumi.Output[dict[str, Any]]
 
     def __init__(
         self,


### PR DESCRIPTION
This PR make changes to fix the pulumi runtime errors:

- Class annotation meta relaxed from pulumi.Output[dict[str, str | list[str]]] to pulumi.Output[dict[str, Any]], this is the one Pulumi's runtime introspects

- Constructor parameter meta: kept as dict[str, str | list[str]] | None — this contract is only read by callers and type checkers, so the tight typing stays.

- Added a short comment explaining why the runtime annotation has to be wider than the input contract, so nobody tightens it back later without hitting the same crash.