### PR TITLE
Add new config option to allow nested analysis runner workflows

### DIFF
--- a/cpg_infra/config/config.py
+++ b/cpg_infra/config/config.py
@@ -420,6 +420,12 @@ class CPGDatasetConfig(ConfigModel):
     # time-limited access via a broker service account.
     allow_notebook_tmp_main_read: bool = False
 
+    # Add the dataset's standard & full Hail service accounts to the analysis group, so
+    # Hail Batch workflows can kick off other Hail Batch workflows via analysis runner.
+    # `test` access level is excluded to disallow starting of standard/full workflows
+    # from a test workflow.
+    allow_nested_analysis_runner_jobs: bool = False
+
     # give FULL access to these datasets, as this dataset depends_on them
     depends_on: list[str] = Field(default_factory=list)
     # give READONLY access to these datasets, as this dataset needs it

--- a/cpg_infra/driver.py
+++ b/cpg_infra/driver.py
@@ -1311,8 +1311,27 @@ class CPGDatasetCloudInfrastructure:
             self.full_group,
         )
 
+        self.setup_analysis_chaining_group_memberships()
+
         if isinstance(self.infra, GcpInfrastructure):
             self.setup_gcp_monitoring_access()
+
+    def setup_analysis_chaining_group_memberships(self):
+        """Optionally add the standard & full Hail SAs to the analysis group so Hail
+        Batch workflows can kick off other Hail Batch workflows via analysis-runner."""
+        if not (
+            self.dataset_config.allow_nested_analysis_runner_jobs
+            and self.should_setup_hail
+        ):
+            return
+        for access_level in ('standard', 'full'):
+            hail_account = self.hail_accounts_by_access_level.get(access_level)
+            if not hail_account:
+                continue
+            self.analysis_group.add_member(
+                self.infra.get_pulumi_name(f'hail-{access_level}-in-analysis-chaining'),
+                member=hail_account.cloud_id,
+            )
 
     @cached_property
     def data_manager_group(self):


### PR DESCRIPTION
It is useful to be able to start an analysis runner job from a running workflow. This change adds a new config option `allow_nested_analysis_runner_jobs` which, when enabled, will add the standard and full hail service accounts to the analysis group. This will allow them to submit a job to analysis runner. There are some additional permissions that this change will bestow upon the service account:

- read access to cpg-common and analysis-runner artifact registry images
- read access to cpg-common storage buckets, and write access to cpg-common test buckets.

These are required for accessing the analysis runner image and accessing config stored in cpg-common.