### PR TITLE
SET-1068 Use GitHub owner ID in WIF attribute condition

### DIFF
--- a/cpg_infra/github_wif/driver.py
+++ b/cpg_infra/github_wif/driver.py
@@ -22,6 +22,7 @@ from cpg_infra.config.base import ConfigModel
 WIF_POOL_NAME = 'github-pool'
 WIF_PROVIDER_NAME = 'github-provider'
 GITHUB_ORG = 'populationgenomics'
+GITHUB_ORG_ID = '69879407'
 
 # Service account name max length is 30 characters
 SA_NAME_MAX_LENGTH = 30
@@ -192,7 +193,7 @@ def check_or_create_wif_provider(
             'attribute.actor': 'assertion.actor',
             'attribute.repository': 'assertion.repository',
         },
-        attribute_condition=f"assertion.repository_owner == '{GITHUB_ORG}'",
+        attribute_condition=f"assertion.repository_owner_id == '{GITHUB_ORG_ID}'",
         oidc=gcp.iam.WorkloadIdentityPoolProviderOidcArgs(
             issuer_uri='https://token.actions.githubusercontent.com',
         ),


### PR DESCRIPTION
Gates the GitHub Actions workload identity provider on the org's immutable numeric ID (`69879407`) instead of its name, so renaming the org can't break OIDC auth.

```diff
-attribute_condition=f"assertion.repository_owner == '{GITHUB_ORG}'",
+attribute_condition=f"assertion.repository_owner_id == '{GITHUB_ORG_ID}'",
```

`GITHUB_ORG` stays — still used for the provider description.

[SET-867](https://cpg-populationanalysis.atlassian.net/browse/SET-867) spiked this

`github-pool/github-provider` is already on `repository_owner_id` in GCP, so applying it is safe and that also reconciles drift in Pulumi state. `github-pam-broker-provider` is the one that actually changes.

[SET-867]: https://cpg-populationanalysis.atlassian.net/browse/SET-867