### PR TITLE
Set 1258 create seqera resources

### DIFF
--- a/cpg_infra/config/__init__.py
+++ b/cpg_infra/config/__init__.py
@@ -11,4 +11,5 @@ from cpg_infra.config.config import (
     GroupName,
     HailAccount,
     MemberKey,
+    SeqeraAccount,
 )

--- a/cpg_infra/config/config.py
+++ b/cpg_infra/config/config.py
@@ -311,6 +311,19 @@ class HailAccount(ConfigModel):
     cloud_id: str | pulumi.Output[str]
 
 
+class SeqeraAccount(ConfigModel):
+    """A Seqera-facing GCP service account for one dataset+access-level.
+
+    cloud_id holds the SA email; may be a pulumi.Output at construction time
+    (same reason as HailAccount — pydantic isn't aware of pulumi types).
+    """
+
+    model_config = ConfigModel.model_config | {'arbitrary_types_allowed': True}
+
+    account_id: str
+    cloud_id: str | pulumi.Output[str]
+
+
 class CPGDatasetConfig(ConfigModel):
     """
     Configuration that describes the minimum information

--- a/cpg_infra/config/config.py
+++ b/cpg_infra/config/config.py
@@ -172,6 +172,24 @@ class CPGInfrastructureConfig(ConfigModel):
         etl: ETLConfiguration | None = None
         slack_channel: str | None = None
 
+    class Seqera(ConfigModel):
+        """Global Seqera Platform configuration.
+
+        Set to enable Seqera integration for any dataset that opts in via
+        CPGDatasetComponents.SEQERA_ACCOUNTS.
+        """
+
+        org_id: int
+        # Seqera Cloud OIDC issuer URI, see:
+        # https://docs.seqera.io/platform-cloud/credentials/overview#google-cloud
+        wif_issuer_uri: str
+        # Seqera workspace ID per dataset team_ownership value.
+        # Keys MUST match the CPGDatasetConfig.team_ownership Literal.
+        workspace_ids: dict[
+            Literal['Rare Disease', 'Population Genomics', 'Shared'],
+            int,
+        ]
+
     class Billing(ConfigModel):
         class GCP(ConfigModel):
             """Details of the BILLING account"""
@@ -246,6 +264,8 @@ class CPGInfrastructureConfig(ConfigModel):
     cromwell: Cromwell | None = None
     # configuration options for our metamist service
     metamist: Metamist | None = None
+    # configuration options for Seqera platform
+    seqera: Seqera | None = None
     # configuration options for billing + billing aggregation
     billing: Billing | None = None
     # list of additional adhoc groups under infrastructure management

--- a/cpg_infra/config/config.py
+++ b/cpg_infra/config/config.py
@@ -307,7 +307,7 @@ class CPGDatasetComponents(Enum):
     ):
         # Explicit lists so that opt-in components (e.g. SEQERA_ACCOUNTS)
         # can be added to the enum without silently enabling them fleet-wide.
-        _default_gcp: list['CPGDatasetComponents'] = [
+        _default_gcp: list[CPGDatasetComponents] = [
             CPGDatasetComponents.STORAGE,
             CPGDatasetComponents.SPARK,
             CPGDatasetComponents.CROMWELL,

--- a/cpg_infra/config/config.py
+++ b/cpg_infra/config/config.py
@@ -279,14 +279,27 @@ class CPGDatasetComponents(Enum):
     METAMIST = 'metamist'
     CONTAINER_REGISTRY = 'container-registry'
     ANALYSIS_RUNNER = 'analysis-runner'
+    SEQERA_ACCOUNTS = 'seqera-accounts'
 
     @staticmethod
     def default_component_for_infrastructure() -> (
         dict[str, list['CPGDatasetComponents']]
     ):
+        # Explicit lists so that opt-in components (e.g. SEQERA_ACCOUNTS)
+        # can be added to the enum without silently enabling them fleet-wide.
+        _default_gcp: list['CPGDatasetComponents'] = [
+            CPGDatasetComponents.STORAGE,
+            CPGDatasetComponents.SPARK,
+            CPGDatasetComponents.CROMWELL,
+            CPGDatasetComponents.NOTEBOOKS,
+            CPGDatasetComponents.HAIL_ACCOUNTS,
+            CPGDatasetComponents.METAMIST,
+            CPGDatasetComponents.CONTAINER_REGISTRY,
+            CPGDatasetComponents.ANALYSIS_RUNNER,
+        ]
         return {
-            'dry-run': list(CPGDatasetComponents),
-            'gcp': list(CPGDatasetComponents),
+            'dry-run': list(_default_gcp),
+            'gcp': list(_default_gcp),
             'azure': [
                 CPGDatasetComponents.STORAGE,
                 CPGDatasetComponents.HAIL_ACCOUNTS,

--- a/cpg_infra/driver/__init__.py
+++ b/cpg_infra/driver/__init__.py
@@ -17,6 +17,7 @@ from cpg_infra.config import (
     CPGInfrastructureConfig,
     CPGInfrastructureUser,
     HailAccount,
+    SeqeraAccount,
 )
 from cpg_infra.driver.constants import (
     METAMIST_PERMISSIONS,

--- a/cpg_infra/driver/dataset_cloud_infrastructure.py
+++ b/cpg_infra/driver/dataset_cloud_infrastructure.py
@@ -103,9 +103,33 @@ class CPGDatasetCloudInfrastructure:
         self.should_setup_analysis_runner = (
             CPGDatasetComponents.ANALYSIS_RUNNER in self.components
         )
+        self.should_setup_seqera = self._resolve_should_setup_seqera()
 
         # outputs
         self.storage_tomls: dict = {}
+
+    def _resolve_should_setup_seqera(self) -> bool:
+        component_enabled = CPGDatasetComponents.SEQERA_ACCOUNTS in self.components
+        if not component_enabled:
+            return False
+        if not isinstance(self.infra, GcpInfrastructure):
+            # Defence-in-depth: SEQERA_ACCOUNTS on non-GCP is silently ignored.
+            return False
+        if self.dataset_config.team_ownership is None:
+            raise ValueError(
+                f'{self.dataset_config.dataset}: SEQERA_ACCOUNTS component is '
+                'enabled but team_ownership is not set. Seqera integration '
+                'requires a team_ownership value to bind the WIF principal '
+                'to a Seqera workspace.',
+            )
+        if self.config.seqera is None:
+            raise ValueError(
+                f'{self.dataset_config.dataset}: SEQERA_ACCOUNTS component is '
+                'enabled but CPGInfrastructureConfig.seqera is not set. '
+                'Configure the global Seqera block (org_id, wif_issuer_uri, '
+                'workspace_ids) before enabling Seqera on any dataset.',
+            )
+        return True
 
     def create_group(self, name: str, cache_members: bool = False):
         """

--- a/cpg_infra/driver/dataset_cloud_infrastructure.py
+++ b/cpg_infra/driver/dataset_cloud_infrastructure.py
@@ -1290,23 +1290,6 @@ class CPGDatasetCloudInfrastructure:
         self.setup_hail_bucket_permissions()
         self.setup_hail_wheels_bucket_permissions()
 
-    # region SEQERA
-
-    @cached_property
-    def seqera(self) -> DatasetSeqeraInfrastructure:
-        return DatasetSeqeraInfrastructure(self)
-
-    def setup_seqera(self) -> None:
-        self.seqera.setup()
-
-    @cached_property
-    def seqera_accounts_by_access_level(self) -> dict[str, SeqeraAccount]:
-        if not self.should_setup_seqera:
-            return {}
-        return self.seqera.accounts_by_access_level
-
-    # endregion SEQERA
-
     @cached_property
     def hail_batch_url(self):
         if isinstance(self.infra, GcpInfrastructure):
@@ -1475,6 +1458,22 @@ class CPGDatasetCloudInfrastructure:
         )
 
     # endregion HAIL
+    # region SEQERA
+
+    @cached_property
+    def seqera(self) -> DatasetSeqeraInfrastructure:
+        return DatasetSeqeraInfrastructure(self)
+
+    def setup_seqera(self) -> None:
+        self.seqera.setup()
+
+    @cached_property
+    def seqera_accounts_by_access_level(self) -> dict[str, SeqeraAccount]:
+        if not self.should_setup_seqera:
+            return {}
+        return self.seqera.accounts_by_access_level
+
+    # endregion SEQERA
     # region CROMWELL
 
     def setup_cromwell(self):

--- a/cpg_infra/driver/dataset_cloud_infrastructure.py
+++ b/cpg_infra/driver/dataset_cloud_infrastructure.py
@@ -37,6 +37,7 @@ from cpg_infra.config import (
     CPGDatasetConfig,
     CPGInfrastructureConfig,
     HailAccount,
+    SeqeraAccount,
 )
 from cpg_infra.driver.constants import (
     METAMIST_PERMISSIONS,
@@ -52,6 +53,9 @@ from cpg_infra.driver.constants import (
     access_levels,
     compute_hash,
     dict_to_toml,
+)
+from cpg_infra.driver.dataset_seqera_infrastructure import (
+    DatasetSeqeraInfrastructure,
 )
 from cpg_infra.driver.main_upload_bucket import MainUploadBucket
 from cpg_infra.driver.sm_accessor_membership import (
@@ -158,6 +162,8 @@ class CPGDatasetCloudInfrastructure:
             self.setup_metamist()
         if self.should_setup_hail:
             self.setup_hail()
+        if self.should_setup_seqera:
+            self.setup_seqera()
         if self.should_setup_cromwell:
             self.setup_cromwell()
         if self.should_setup_spark:
@@ -195,6 +201,8 @@ class CPGDatasetCloudInfrastructure:
 
         for access_level, account in self.hail_accounts_by_access_level.items():
             machine_accounts['hail'].append((access_level, account.cloud_id))
+        for access_level, account in self.seqera_accounts_by_access_level.items():
+            machine_accounts['seqera'].append((access_level, account.cloud_id))
         for access_level, account in self.deployment_accounts_by_access_level.items():
             machine_accounts['deployment'].append((access_level, account))
         for (
@@ -1281,6 +1289,23 @@ class CPGDatasetCloudInfrastructure:
         self.setup_git_checkout_token_permissions()
         self.setup_hail_bucket_permissions()
         self.setup_hail_wheels_bucket_permissions()
+
+    # region SEQERA
+
+    @cached_property
+    def seqera(self) -> DatasetSeqeraInfrastructure:
+        return DatasetSeqeraInfrastructure(self)
+
+    def setup_seqera(self) -> None:
+        self.seqera.setup()
+
+    @cached_property
+    def seqera_accounts_by_access_level(self) -> dict[str, SeqeraAccount]:
+        if not self.should_setup_seqera:
+            return {}
+        return self.seqera.accounts_by_access_level
+
+    # endregion SEQERA
 
     @cached_property
     def hail_batch_url(self):

--- a/cpg_infra/driver/dataset_seqera_infrastructure.py
+++ b/cpg_infra/driver/dataset_seqera_infrastructure.py
@@ -14,11 +14,23 @@ from __future__ import annotations
 from functools import cached_property
 from typing import TYPE_CHECKING
 
+import pulumi_gcp as gcp
+
+from cpg_infra.config import SeqeraAccount
+
 if TYPE_CHECKING:
-    from cpg_infra.config import SeqeraAccount
     from cpg_infra.driver.dataset_cloud_infrastructure import (
         CPGDatasetCloudInfrastructure,
     )
+
+_ACCESS_LEVELS_ALWAYS = ('full', 'standard')
+_ACCESS_LEVEL_TEST = 'test'
+
+_SEQERA_SA_PROJECT_ROLES: tuple[str, ...] = (
+    'roles/batch.jobsEditor',
+    'roles/batch.agentReporter',
+    'roles/logging.logWriter',
+)
 
 
 class DatasetSeqeraInfrastructure:
@@ -31,17 +43,124 @@ class DatasetSeqeraInfrastructure:
         self._infra = parent.infra
 
     @cached_property
+    def _access_levels(self) -> list[str]:
+        levels = list(_ACCESS_LEVELS_ALWAYS)
+        if self._dataset_config.setup_test:
+            levels.append(_ACCESS_LEVEL_TEST)
+        return levels
+
+    @cached_property
+    def _workspace_id(self) -> int:
+        # By the time this property is read, should_setup_seqera on the parent
+        # has already validated that seqera config and team_ownership exist.
+        assert self._config.seqera is not None
+        assert self._dataset_config.team_ownership is not None
+        return self._config.seqera.workspace_ids[
+            self._dataset_config.team_ownership
+        ]
+
+    @cached_property
+    def _wif_pool(self) -> gcp.iam.WorkloadIdentityPool:
+        pool_id = f'seqera-{self._dataset_config.dataset}'
+        return gcp.iam.WorkloadIdentityPool(
+            self._infra.get_pulumi_name(f'seqera-wif-pool-{self._dataset_config.dataset}'),
+            workload_identity_pool_id=pool_id,
+            display_name=f'Seqera WIF pool for {self._dataset_config.dataset}',
+            description=(
+                'Federates Seqera Cloud OIDC tokens to per-dataset GCP '
+                'service accounts.'
+            ),
+            project=self._infra.project_id,
+        )
+
+    @cached_property
+    def _wif_provider(self) -> gcp.iam.WorkloadIdentityPoolProvider:
+        assert self._config.seqera is not None
+        return gcp.iam.WorkloadIdentityPoolProvider(
+            self._infra.get_pulumi_name(
+                f'seqera-wif-provider-{self._dataset_config.dataset}',
+            ),
+            workload_identity_pool_id=self._wif_pool.workload_identity_pool_id,
+            workload_identity_pool_provider_id=(
+                f'seqera-{self._dataset_config.dataset}-oidc'
+            ),
+            display_name='Seqera Cloud OIDC',
+            project=self._infra.project_id,
+            oidc=gcp.iam.WorkloadIdentityPoolProviderOidcArgs(
+                issuer_uri=self._config.seqera.wif_issuer_uri,
+            ),
+            attribute_mapping={'google.subject': 'assertion.sub'},
+        )
+
+    @cached_property
+    def _service_accounts(
+        self,
+    ) -> dict[str, gcp.serviceaccount.Account]:
+        return {
+            level: self._infra.create_machine_account(
+                f'seqera-{self._dataset_config.dataset}-{level}',
+            )
+            for level in self._access_levels
+        }
+
+    @cached_property
     def accounts_by_access_level(self) -> dict[str, SeqeraAccount]:
         """The three Seqera SAs keyed by access level.
 
         Populated when setup() runs; empty until then.
+
+        account_id is built from the same plain string passed to
+        create_machine_account() rather than read back from
+        sa.account_id, because pulumi_gcp's Account.account_id is a
+        pulumi.Output[str] at runtime, and SeqeraAccount.account_id is
+        typed as a plain str (unlike cloud_id, which explicitly allows
+        a pulumi.Output).
         """
-        return {}
+        return {
+            level: SeqeraAccount(
+                account_id=f'seqera-{self._dataset_config.dataset}-{level}',
+                cloud_id=sa.email,
+            )
+            for level, sa in self._service_accounts.items()
+        }
 
     def setup(self) -> None:
         """Materialise WIF pool, provider, SAs, and IAM bindings.
 
         Idempotent — cached_properties gate resource creation.
         """
-        # Filled in by Task 6.
-        return
+        self._grant_project_roles()
+        self._bind_wif_principals()
+
+    def _grant_project_roles(self) -> None:
+        for level, sa in self._service_accounts.items():
+            for role in _SEQERA_SA_PROJECT_ROLES:
+                role_slug = role.split('/')[-1].replace('.', '-')
+                self._infra.add_project_role(
+                    f'seqera-{self._dataset_config.dataset}-{level}-{role_slug}',
+                    member=sa,
+                    role=role,
+                )
+
+    def _bind_wif_principals(self) -> None:
+        assert self._config.seqera is not None
+        org_id = self._config.seqera.org_id
+        workspace_id = self._workspace_id
+        wif_subject = f'org:{org_id}:wsp:{workspace_id}:workflow'
+        principal = self._wif_pool.name.apply(
+            lambda pool_name: (
+                f'principal://iam.googleapis.com/{pool_name}/subject/{wif_subject}'
+            ),
+        )
+        # Ensure the provider is materialised so pool exists before bindings.
+        _ = self._wif_provider
+
+        for level, sa in self._service_accounts.items():
+            gcp.serviceaccount.IAMMember(
+                self._infra.get_pulumi_name(
+                    f'seqera-{self._dataset_config.dataset}-{level}-wif-user',
+                ),
+                service_account_id=sa.name,
+                role='roles/iam.workloadIdentityUser',
+                member=principal,
+            )

--- a/cpg_infra/driver/dataset_seqera_infrastructure.py
+++ b/cpg_infra/driver/dataset_seqera_infrastructure.py
@@ -97,22 +97,25 @@ class DatasetSeqeraInfrastructure:
             attribute_mapping={'google.subject': 'assertion.sub'},
         )
 
+    def _account_id_for(self, level: str) -> str:
+        # SAs are project-scoped (each dataset has its own GCP project), so
+        # the dataset name would be redundant in the account_id. Keeping it
+        # short also stays within GCP's 30-char account_id limit for datasets
+        # with long names.
+        return f'seqera-{level}'
+
     @cached_property
     def _service_accounts(
         self,
     ) -> dict[str, gcp.serviceaccount.Account]:
         return {
-            level: self._infra.create_machine_account(
-                f'seqera-{self._dataset_config.dataset}-{level}',
-            )
+            level: self._infra.create_machine_account(self._account_id_for(level))
             for level in self._access_levels
         }
 
     @cached_property
     def accounts_by_access_level(self) -> dict[str, SeqeraAccount]:
         """The three Seqera SAs keyed by access level.
-
-        Populated when setup() runs; empty until then.
 
         account_id is built from the same plain string passed to
         create_machine_account() rather than read back from
@@ -123,7 +126,7 @@ class DatasetSeqeraInfrastructure:
         """
         return {
             level: SeqeraAccount(
-                account_id=f'seqera-{self._dataset_config.dataset}-{level}',
+                account_id=self._account_id_for(level),
                 cloud_id=sa.email,
             )
             for level, sa in self._service_accounts.items()
@@ -142,7 +145,7 @@ class DatasetSeqeraInfrastructure:
             for role in _SEQERA_SA_PROJECT_ROLES:
                 role_slug = role.split('/')[-1].replace('.', '-')
                 self._infra.add_project_role(
-                    f'seqera-{self._dataset_config.dataset}-{level}-{role_slug}',
+                    f'seqera-{level}-{role_slug}',
                     member=sa,
                     role=role,
                 )
@@ -162,9 +165,7 @@ class DatasetSeqeraInfrastructure:
 
         for level, sa in self._service_accounts.items():
             gcp.serviceaccount.IAMMember(
-                self._infra.get_pulumi_name(
-                    f'seqera-{self._dataset_config.dataset}-{level}-wif-user',
-                ),
+                self._infra.get_pulumi_name(f'seqera-{level}-wif-user'),
                 service_account_id=sa.name,
                 role='roles/iam.workloadIdentityUser',
                 member=principal,

--- a/cpg_infra/driver/dataset_seqera_infrastructure.py
+++ b/cpg_infra/driver/dataset_seqera_infrastructure.py
@@ -1,0 +1,47 @@
+"""Per-dataset Seqera Platform integration.
+
+Creates the GCP service accounts, Workload Identity Federation pool +
+OIDC provider, and IAM bindings that let Seqera Cloud run Google Batch
+jobs on the dataset's behalf. Workspaces themselves are created manually
+in Seqera and referenced via CPGInfrastructureConfig.seqera.workspace_ids.
+
+Gating (should_setup_seqera) lives on CPGDatasetCloudInfrastructure —
+this class assumes it is only instantiated when it should run.
+"""
+
+from __future__ import annotations
+
+from functools import cached_property
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from cpg_infra.config import SeqeraAccount
+    from cpg_infra.driver.dataset_cloud_infrastructure import (
+        CPGDatasetCloudInfrastructure,
+    )
+
+
+class DatasetSeqeraInfrastructure:
+    """Owns all Seqera-related resources for one dataset."""
+
+    def __init__(self, parent: CPGDatasetCloudInfrastructure) -> None:
+        self._parent = parent
+        self._config = parent.config
+        self._dataset_config = parent.dataset_config
+        self._infra = parent.infra
+
+    @cached_property
+    def accounts_by_access_level(self) -> dict[str, SeqeraAccount]:
+        """The three Seqera SAs keyed by access level.
+
+        Populated when setup() runs; empty until then.
+        """
+        return {}
+
+    def setup(self) -> None:
+        """Materialise WIF pool, provider, SAs, and IAM bindings.
+
+        Idempotent — cached_properties gate resource creation.
+        """
+        # Filled in by Task 6.
+        return

--- a/cpg_infra/driver/dataset_seqera_infrastructure.py
+++ b/cpg_infra/driver/dataset_seqera_infrastructure.py
@@ -16,6 +16,7 @@ from typing import TYPE_CHECKING
 
 import pulumi_gcp as gcp
 
+from cpg_infra.abstraction.gcp import GcpInfrastructure
 from cpg_infra.config import SeqeraAccount
 
 if TYPE_CHECKING:
@@ -37,10 +38,14 @@ class DatasetSeqeraInfrastructure:
     """Owns all Seqera-related resources for one dataset."""
 
     def __init__(self, parent: CPGDatasetCloudInfrastructure) -> None:
+        assert isinstance(parent.infra, GcpInfrastructure), (
+            'DatasetSeqeraInfrastructure requires GcpInfrastructure; '
+            'gating lives on CPGDatasetCloudInfrastructure.should_setup_seqera.'
+        )
         self._parent = parent
         self._config = parent.config
         self._dataset_config = parent.dataset_config
-        self._infra = parent.infra
+        self._infra: GcpInfrastructure = parent.infra
 
     @cached_property
     def _access_levels(self) -> list[str]:
@@ -55,15 +60,15 @@ class DatasetSeqeraInfrastructure:
         # has already validated that seqera config and team_ownership exist.
         assert self._config.seqera is not None
         assert self._dataset_config.team_ownership is not None
-        return self._config.seqera.workspace_ids[
-            self._dataset_config.team_ownership
-        ]
+        return self._config.seqera.workspace_ids[self._dataset_config.team_ownership]
 
     @cached_property
     def _wif_pool(self) -> gcp.iam.WorkloadIdentityPool:
         pool_id = f'seqera-{self._dataset_config.dataset}'
         return gcp.iam.WorkloadIdentityPool(
-            self._infra.get_pulumi_name(f'seqera-wif-pool-{self._dataset_config.dataset}'),
+            self._infra.get_pulumi_name(
+                f'seqera-wif-pool-{self._dataset_config.dataset}'
+            ),
             workload_identity_pool_id=pool_id,
             display_name=f'Seqera WIF pool for {self._dataset_config.dataset}',
             description=(

--- a/test/test_config_validation.py
+++ b/test/test_config_validation.py
@@ -142,3 +142,17 @@ class TestConfigValidation(TestCase):
             budgets={'dry-run': CPGDatasetConfig.Budget(monthly_budget=100)},
         )
         self.assertEqual(100, config.budgets['dry-run'].monthly_budget)
+
+    def test_seqera_account_model_parses(self):
+        """SeqeraAccount round-trips minimal valid input"""
+        from cpg_infra.config import SeqeraAccount
+
+        account = SeqeraAccount(
+            account_id='seqera-my-dataset-full',
+            cloud_id='seqera-my-dataset-full@project.iam.gserviceaccount.com',
+        )
+        self.assertEqual('seqera-my-dataset-full', account.account_id)
+        self.assertEqual(
+            'seqera-my-dataset-full@project.iam.gserviceaccount.com',
+            account.cloud_id,
+        )

--- a/test/test_config_validation.py
+++ b/test/test_config_validation.py
@@ -156,3 +156,28 @@ class TestConfigValidation(TestCase):
             'seqera-my-dataset-full@project.iam.gserviceaccount.com',
             account.cloud_id,
         )
+
+    def test_seqera_accounts_component_string_coercion(self):
+        """The 'seqera-accounts' string coerces to the enum member"""
+        config = CPGDatasetConfig.model_validate(
+            {
+                'dataset': 'DATASET',
+                'budgets': {},
+                'gcp': {'project': 'dataset-1234'},
+                'components': {'gcp': ['seqera-accounts']},
+            },
+        )
+        self.assertEqual(
+            [CPGDatasetComponents.SEQERA_ACCOUNTS],
+            config.components['gcp'],
+        )
+
+    def test_seqera_accounts_not_in_defaults(self):
+        """SEQERA_ACCOUNTS is opt-in only — not in any default component set"""
+        defaults = CPGDatasetComponents.default_component_for_infrastructure()
+        for cloud, components in defaults.items():
+            self.assertNotIn(
+                CPGDatasetComponents.SEQERA_ACCOUNTS,
+                components,
+                f'SEQERA_ACCOUNTS should not be in default components for {cloud}',
+            )

--- a/test/test_config_validation.py
+++ b/test/test_config_validation.py
@@ -181,3 +181,38 @@ class TestConfigValidation(TestCase):
                 components,
                 f'SEQERA_ACCOUNTS should not be in default components for {cloud}',
             )
+
+    def test_seqera_infra_config_parses(self):
+        """CPGInfrastructureConfig.Seqera parses a minimal valid block"""
+        seqera = CPGInfrastructureConfig.Seqera.model_validate(
+            {
+                'org_id': 12345,
+                'wif_issuer_uri': 'https://cloud.seqera.io',
+                'workspace_ids': {
+                    'Rare Disease': 111,
+                    'Population Genomics': 222,
+                    'Shared': 333,
+                },
+            },
+        )
+        self.assertEqual(12345, seqera.org_id)
+        self.assertEqual(111, seqera.workspace_ids['Rare Disease'])
+
+    def test_seqera_workspace_ids_reject_unknown_team(self):
+        """workspace_ids with a team key outside the Literal must raise"""
+        with self.assertRaises(ValidationError):
+            CPGInfrastructureConfig.Seqera.model_validate(
+                {
+                    'org_id': 1,
+                    'wif_issuer_uri': 'https://cloud.seqera.io',
+                    'workspace_ids': {'Rare-Disease': 111},  # note the hyphen typo
+                },
+            )
+
+    def test_seqera_optional_on_infrastructure_config(self):
+        """CPGInfrastructureConfig.seqera defaults to None"""
+        # Just verify the attribute exists on the class with the right default;
+        # constructing a full CPGInfrastructureConfig here is heavy, so this
+        # inspects the model field definition.
+        field = CPGInfrastructureConfig.model_fields['seqera']
+        self.assertIsNone(field.default)

--- a/test/test_seqera_infrastructure.py
+++ b/test/test_seqera_infrastructure.py
@@ -1,0 +1,101 @@
+"""Behavioural tests for the Seqera driver integration."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from unittest import TestCase
+from unittest.mock import MagicMock
+
+from cpg_infra.config import (
+    CPGDatasetConfig,
+    CPGInfrastructureConfig,
+)
+
+if TYPE_CHECKING:
+    from cpg_infra.driver.dataset_cloud_infrastructure import (
+        CPGDatasetCloudInfrastructure,
+    )
+
+
+def _make_dataset_config(
+    *,
+    team_ownership: str | None,
+    components: list[str],
+) -> CPGDatasetConfig:
+    return CPGDatasetConfig.model_validate(
+        {
+            'dataset': 'DATASET',
+            'budgets': {},
+            'gcp': {'project': 'dataset-1234'},
+            'team_ownership': team_ownership,
+            'components': {'gcp': components},
+        },
+    )
+
+
+class TestShouldSetupSeqeraGate(TestCase):
+    """The should_setup_seqera gate on CPGDatasetCloudInfrastructure."""
+
+    def _make_driver(
+        self,
+        *,
+        team_ownership: str | None,
+        components: list[str],
+        seqera_configured: bool = True,
+        infra_is_gcp: bool = True,
+    ) -> CPGDatasetCloudInfrastructure:
+        from cpg_infra.abstraction.gcp import GcpInfrastructure
+        from cpg_infra.driver.dataset_cloud_infrastructure import (
+            CPGDatasetCloudInfrastructure,
+        )
+
+        infra = MagicMock(spec=GcpInfrastructure if infra_is_gcp else object)
+        infra.name.return_value = 'gcp' if infra_is_gcp else 'azure'
+
+        infra_config = MagicMock(spec=CPGInfrastructureConfig)
+        infra_config.seqera = MagicMock() if seqera_configured else None
+
+        dataset_config = _make_dataset_config(
+            team_ownership=team_ownership,
+            components=components,
+        )
+        return CPGDatasetCloudInfrastructure(
+            config=infra_config,
+            root=MagicMock(),
+            group_provider=MagicMock(),
+            infra=infra,
+            dataset_config=dataset_config,
+        )
+
+    def test_gate_true_when_component_and_team_and_gcp(self):
+        driver = self._make_driver(
+            team_ownership='Rare Disease',
+            components=['seqera-accounts'],
+        )
+        self.assertTrue(driver.should_setup_seqera)
+
+    def test_gate_false_when_component_absent(self):
+        driver = self._make_driver(
+            team_ownership='Rare Disease',
+            components=['storage'],
+        )
+        self.assertFalse(driver.should_setup_seqera)
+
+    def test_component_without_team_ownership_raises(self):
+        """SEQERA_ACCOUNTS in components + missing team_ownership = config error"""
+        with self.assertRaises(ValueError) as ctx:
+            self._make_driver(
+                team_ownership=None,
+                components=['seqera-accounts'],
+            )
+        self.assertIn('team_ownership', str(ctx.exception))
+
+    def test_component_without_global_seqera_config_raises(self):
+        """SEQERA_ACCOUNTS in components + no CPGInfrastructureConfig.seqera = config error"""
+        with self.assertRaises(ValueError) as ctx:
+            self._make_driver(
+                team_ownership='Rare Disease',
+                components=['seqera-accounts'],
+                seqera_configured=False,
+            )
+        self.assertIn('seqera', str(ctx.exception).lower())


### PR DESCRIPTION
Adds Seqera Platform integration to the driver: per-dataset GCP service accounts + Workload Identity Federation, wired into the existing access-level-group plumbing so Seqera SAs inherit the same bucket / metamist permissions Hail SAs have.

What is included:

- CPGDatasetComponents.SEQERA_ACCOUNTS — new opt-in component. Not in any cloud's default set; datasets enable it by listing seqera-accounts in components.gcp.
- CPGInfrastructureConfig.Seqera — new global config block: org_id, wif_issuer_uri, workspace_ids (keyed by team_ownership values).
- SeqeraAccount — new pydantic model, mirroring HailAccount.
- DatasetSeqeraInfrastructure — new class (cpg_infra/driver/dataset_seqera_infrastructure.py) that provisions per opted-in dataset:
- Three GCP SAs (seqera-{full,standard,test}) with roles/batch.jobsEditor, roles/batch.agentReporter, roles/logging.logWriter on the dataset project.
- One WIF pool + OIDC provider bound to the Seqera issuer.
- workloadIdentityUser bindings per SA against subject org:{org}:wsp:{workspace_id_for_team}:workflow.
- Wiring into CPGDatasetCloudInfrastructure: should_setup_seqera gate, delegate methods, and a fold into working_machine_accounts_by_type under kind 'seqera' so the SAs flow through the existing access-level group / bucket IAM / metamist member paths.

Not included

- No Seqera Platform API dynamic resource providers (workspace / credential / compute-env registration). Workspaces are created manually in Seqera and referenced by ID.
- GCP only. Azure component sets do not include SEQERA_ACCOUNTS.

Opt-in

A dataset opts in by listing seqera-accounts in components.gcp and setting team_ownership. Missing team_ownership or missing global CPGInfrastructureConfig.seqera raises a clear ValueError at driver construction -silent skips would drift.

Test plan

- [x] python -m unittest discover test — 24/24 green (7 new tests: SeqeraAccount round-trip, enum coercion, opt-in-only defaults, Seqera block parse, workspace_ids literal rejection, seqera optional default, four should_setup_seqera gate cases).
- [x] pre-commit run --all-files — ruff, ruff-format, mypy all pass.
- [x] pulumi preview in cpg-infrastructure-private with one dataset (thousand-genomes) opted in — verify the expected new resources: 1 WIF pool, 1 OIDC provider, 3 SAs, 9 projects.IAMMember (3 SAs × 3 project roles), 3 serviceaccount.IAMMember (WIF principal bindings). Confirm no unrelated resources destroyed.

Once merged, we need to finalised this PR and merge it afterwards:
https://github.com/populationgenomics/cpg-infrastructure-private/pull/762

